### PR TITLE
fix: null ref exception caused by event trigger before parameter set

### DIFF
--- a/Blazor.Cropper/Blazor.Cropper.csproj
+++ b/Blazor.Cropper/Blazor.Cropper.csproj
@@ -11,7 +11,7 @@
     <RepositoryUrl>https://github.com/Chronostasys/Blazor.Cropper</RepositoryUrl>
     <PackageTags>Blazor,Cropper,Crop,Image</PackageTags>
     <PackageId>Chronos.Blazor.Cropper</PackageId>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Blazor.Cropper/Cropper.razor.cs
+++ b/Blazor.Cropper/Cropper.razor.cs
@@ -253,6 +253,7 @@ namespace Blazor.Cropper
         private IImageFormat _format;
         private Image _gifimage;
         private double _ratio = 1d;
+        private bool _evInitialized = false;
 
         #endregion
 
@@ -270,7 +271,6 @@ namespace Blazor.Cropper
         #region Override methods
         protected override async Task OnInitializedAsync()
         {
-            await JSRuntime.InvokeVoidAsync("addCropperEventListeners");
             await JSRuntime.InvokeVoidAsync("setVersion", Environment.Version.Major);
         }
         protected override void OnParametersSet()
@@ -366,6 +366,11 @@ namespace Blazor.Cropper
                 Width = data[0],
                 Height = data[1]
             };
+            if (!_evInitialized)
+            {
+                await JSRuntime.InvokeVoidAsync("addCropperEventListeners");
+                _evInitialized = true;
+            }
             await SetImgContainterSize();
             MaxRatio = _imgContainerWidth / ImgRealW;
             Ratio = _imgSize / 100;

--- a/Blazor.Cropper/wwwroot/CropHelper.js
+++ b/Blazor.Cropper/wwwroot/CropHelper.js
@@ -127,7 +127,6 @@ var serializeEvent = function (e) {
 };
 
 function setSrc(bin,id) {
-    console.log(bin)
     document.getElementById(id).src = URL.createObjectURL(
         new Blob([bin], { type: 'image/png' })
     );


### PR DESCRIPTION
Issue 36 is an old issue, caused by js emitting onmouseup event before the image data is set.
Simply move the event initialization step from `OninitializedAsync` to `OnParameterSetAsync` shall fix this issue.  
close #36 