### PR TITLE
Added parameters to set the final size of the cropped image

### DIFF
--- a/Blazor.Cropper.sln.DotSettings
+++ b/Blazor.Cropper.sln.DotSettings
@@ -1,0 +1,10 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/USE_HEURISTICS_FOR_BODY_STYLE/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_EXPR_METHOD_ON_SINGLE_LINE/@EntryValue">NEVER</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_ARROW_WITH_EXPRESSIONS/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForOtherTypes/@EntryValue">UseExplicitType</s:String>
+	<s:String x:Key="/Default/CodeStyle/CSharpVarKeywordUsage/ForSimpleTypes/@EntryValue">UseExplicitType</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Blazor.Cropper/Blazor.Cropper/Blazor.Cropper.xml
+++ b/Blazor.Cropper/Blazor.Cropper/Blazor.Cropper.xml
@@ -4,229 +4,247 @@
         <name>Blazor.Cropper</name>
     </assembly>
     <members>
-        <member name="T:Blazor.Cropper.CropInfo">
+        <member name="T:CropInfo">
             <summary>
-            Crop metadata
+                Crop metadata
             </summary>
         </member>
-        <member name="P:Blazor.Cropper.CropInfo.Rectangle">
+        <member name="P:CropInfo.Rectangle">
             <summary>
-            Crop zone in pixel (for original image)
+                Crop zone in pixel (for original image)
             </summary>
         </member>
-        <member name="P:Blazor.Cropper.CropInfo.Ratio">
+        <member name="P:CropInfo.Ratio">
             <summary>
-            ratio
+                ratio
             </summary>
         </member>
-        <member name="P:Blazor.Cropper.CropInfo.ResizeProp">
+        <member name="P:CropInfo.ResizeProp">
             <summary>
-            resizeprop
+                resizeprop
             </summary>
         </member>
-        <member name="M:Blazor.Cropper.CropInfo.GetInitParams">
+        <member name="M:CropInfo.GetInitParams">
             <summary>
-            Get init parameters from this function to restore the cropper state
-            note that the data returned from this function is in physical pixel
+                Get init parameters from this function to restore the cropper state
+                note that the data returned from this function is in physical pixel
             </summary>
             <returns></returns>
         </member>
+        <member name="T:Blazor.Cropper.Cropper">
+            <summary>
+                Cropper component
+            </summary>
+        </member>
+        <member name="P:Blazor.Cropper.Cropper.FinalCropHeight">
+            whether use c# for ordinary img processing
+        </member>
+        <member name="P:Blazor.Cropper.Cropper.FinalCropWidth">
+            whether use c# for ordinary img processing
+        </member>
         <member name="P:Blazor.Cropper.Cropper.PureCSharpProcessing">
             <summary>
-            whether use c# for ordinary img processing
+                whether use c# for ordinary img processing
             </summary>
             <value>default: false</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.IsImageLocked">
             <summary>
-            If this property is true, the image will become
-            unresizable in cropper
+                If this property is true, the image will become
+                unresizable in cropper
             </summary>
             <value>default: true</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.InitCropWidth">
             <summary>
-            the initial width of cropper if possible.
-            shall not be smaller than 30.
+                the initial width of cropper if possible.
+                shall not be smaller than 30.
             </summary>
-            <remarks>It's unit is not pixel. For more info, see <seealso cref="M:Blazor.Cropper.CropInfo.GetInitParams"/></remarks>
+            <remarks>It's unit is not pixel. For more info, see <seealso cref="M:CropInfo.GetInitParams" /></remarks>
             <value>default: 150</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.InitCropHeight">
             <summary>
-            the initial height of cropper if possible.
-            shall not be smaller than 30.
+                the initial height of cropper if possible.
+                shall not be smaller than 30.
             </summary>
-            <remarks>It's unit is not pixel. For more info, see <seealso cref="M:Blazor.Cropper.CropInfo.GetInitParams"/></remarks>
+            <remarks>It's unit is not pixel. For more info, see <seealso cref="M:CropInfo.GetInitParams" /></remarks>
             <value>default: 150</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.RequireAspectRatio">
             <summary>
-            sepecify whether the cropper's aspect ratio is fixed
+                sepecify whether the cropper's aspect ratio is fixed
             </summary>
             <value>default: false</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.AspectRatio">
             <summary>
-            sepecify the cropper's aspect ratio
+                sepecify the cropper's aspect ratio
             </summary>
-            <remarks>Only works when <see cref="P:Blazor.Cropper.Cropper.RequireAspectRatio"/>
-            is true</remarks>
+            <remarks>
+                Only works when <see cref="P:Blazor.Cropper.Cropper.RequireAspectRatio" />
+                is true
+            </remarks>
             <value>default: 1</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.ImageFile">
             <summary>
-            The input image file. Usually get from an
-            <see cref="T:Microsoft.AspNetCore.Components.Forms.InputFile"/> Component. You can also
-            mock a file from stream using <see cref="T:Blazor.Cropper.StreamFile"/> if needed.
+                The input image file. Usually get from an
+                <see cref="T:Microsoft.AspNetCore.Components.Forms.InputFile" /> Component. You can also
+                mock a file from stream using <see cref="T:StreamFile" /> if needed.
             </summary>
             <value></value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.OnLoad">
             <summary>
-            Fire when the image file load into cropper
+                Fire when the image file load into cropper
             </summary>
             <value></value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.AnimeGifEnable">
             <summary>
-            Set whether the anime gif crop is enabled. If enabled,
-            the gif file smaller than 1mb would 
-            be cropped as animed image. If disabled, only the first
-            frame would be cropped.
+                Set whether the anime gif crop is enabled. If enabled,
+                the gif file smaller than 1mb would
+                be cropped as animed image. If disabled, only the first
+                frame would be cropped.
             </summary>
-            <remarks>Crop large gif image can cause the window stop responding
-            for half a minute!</remarks>
+            <remarks>
+                Crop large gif image can cause the window stop responding
+                for half a minute!
+            </remarks>
             <value>default: true</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.InputId">
             <summary>
-            The input element's id value. This param is optional and
-            can help cropper to init image
-            faster on browser before dotnet core version 6.
-            Does't have effect if <see cref="P:Blazor.Cropper.Cropper.PureCSharpProcessing"/> is true.
+                The input element's id value. This param is optional and
+                can help cropper to init image
+                faster on browser before dotnet core version 6.
+                Does't have effect if <see cref="P:Blazor.Cropper.Cropper.PureCSharpProcessing" /> is true.
             </summary>
         </member>
         <member name="P:Blazor.Cropper.Cropper.MaxCropedHeight">
             <summary>
-            Max allowed crop result height. Should not be larger than 500.
+                Max allowed crop result height. Should not be larger than 500.
             </summary>
             <value>default:500</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.MaxCropedWidth">
             <summary>
-            Max allowed crop result width. Should not be larger than 500.
+                Max allowed crop result width. Should not be larger than 500.
             </summary>
             <value>default:500</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.CropperHeight">
             <summary>
-            Height of this component in px
+                Height of this component in px
             </summary>
             <value>default:150</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.IsCropLocked">
             <summary>
-            Whether the cropper size is locked
+                Whether the cropper size is locked
             </summary>
             <value>default: false</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.Ratio">
             <summary>
-            The scaling ratio, should be bind two way.
+                The scaling ratio, should be bind two way.
             </summary>
             <value>default: 1.0</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.RatioChanged">
             <summary>
-            Fire when scaling ratio changed by touch event.
+                Fire when scaling ratio changed by touch event.
             </summary>
         </member>
         <member name="P:Blazor.Cropper.Cropper.OnSizeChanged">
             <summary>
-            Fire when cropper size changed. 
-            Item1 of the return tuple is width, Item2 is height
+                Fire when cropper size changed.
+                Item1 of the return tuple is width, Item2 is height
             </summary>
         </member>
         <member name="P:Blazor.Cropper.Cropper.OffsetX">
             <summary>
-            Used to set the cropper initial offset position.
+                Used to set the cropper initial offset position.
             </summary>
-            <remarks>It's unit is not pixel. For more info, see <seealso cref="M:Blazor.Cropper.CropInfo.GetInitParams"/></remarks>
+            <remarks>It's unit is not pixel. For more info, see <seealso cref="M:CropInfo.GetInitParams" /></remarks>
         </member>
         <member name="P:Blazor.Cropper.Cropper.OffsetY">
             <summary>
-            Used to set the cropper initial offset position.
+                Used to set the cropper initial offset position.
             </summary>
-            <remarks>It's unit is not pixel. For more info, see <seealso cref="M:Blazor.Cropper.CropInfo.GetInitParams"/></remarks>
+            <remarks>It's unit is not pixel. For more info, see <seealso cref="M:CropInfo.GetInitParams" /></remarks>
         </member>
         <member name="P:Blazor.Cropper.Cropper.Quality">
             <summary>
-            Quality of output image. Should be between 0 and 100.
-            Only takes effect when image is in jpg or webp format.
+                Quality of output image. Should be between 0 and 100.
+                Only takes effect when image is in jpg or webp format.
             </summary>
             <value>100</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.MinRatio">
             <summary>
-            Min allowed scaling ratio
+                Min allowed scaling ratio
             </summary>
             <value>1.0</value>
         </member>
         <member name="P:Blazor.Cropper.Cropper.MaxRatio">
             <summary>
-            Max allowed scaling ratio
+                Max allowed scaling ratio
             </summary>
             <remarks>This property is obsolete. Max ratio is no longer limited</remarks>
             <value>2</value>
         </member>
+        <member name="M:Blazor.Cropper.Cropper.OnInitializedAsync">
+            <inheritdoc />
+        </member>
+        <member name="M:Blazor.Cropper.Cropper.OnParametersSet">
+            <inheritdoc />
+        </member>
+        <member name="M:Blazor.Cropper.Cropper.DisposeAsync">
+            <inheritdoc />
+        </member>
+        <member name="M:Blazor.Cropper.Cropper.OnParametersSetAsync">
+            <inheritdoc />
+        </member>
+        <member name="M:Blazor.Cropper.Cropper.OnAfterRenderAsync(System.Boolean)">
+            <inheritdoc />
+        </member>
         <member name="M:Blazor.Cropper.Cropper.GetCropedResult">
             <summary>
-            Get the crop result.
+                Get the crop result.
             </summary>
             <returns>crop result</returns>
         </member>
         <member name="M:Blazor.Cropper.Cropper.GetCropInfo">
             <summary>
-            Returns the metadata about the cropper state.
+                Returns the metadata about the cropper state.
             </summary>
             <returns></returns>
         </member>
-        <member name="M:Blazor.Cropper.ImageCroppedResult.GetDataAsync">
+        <member name="M:ImageCroppedResult.GetDataAsync">
             <summary>
-            get image bytes
+                get image bytes
             </summary>
             <returns>image bytes</returns>
             <exception cref="T:System.InvalidOperationException"></exception>
         </member>
-        <member name="M:Blazor.Cropper.ImageCroppedResult.SaveAsync(System.IO.Stream)">
+        <member name="M:ImageCroppedResult.SaveAsync(System.IO.Stream)">
             <summary>
-            save img data to stream
+                save img data to stream
             </summary>
             <param name="s"></param>
             <returns></returns>
         </member>
-        <member name="M:Blazor.Cropper.ImageCroppedResult.SaveAsync(System.IO.Stream,SixLabors.ImageSharp.Formats.IImageEncoder)">
+        <member name="T:JsInterop">
             <summary>
-            Save image to a stream with your own
-            <see cref="T:SixLabors.ImageSharp.Formats.IImageEncoder"/>.
-            This can be use to
-            set some advanced options e.g. <see cref="T:SixLabors.ImageSharp.Formats.Png.PngCompressionLevel"/> for png.
-            This method can only be used when the cropper working in pure cs mode
-            </summary>
-            <param name="s"></param>
-            <param name="encoder"></param>
-            <returns></returns>
-        </member>
-        <member name="T:Blazor.Cropper.JSInterop">
-            <summary>
-            js interop methods
+                js interop methods
             </summary>
         </member>
-        <member name="M:Blazor.Cropper.JSInterop.SetImageAsync(Microsoft.JSInterop.IJSRuntime,System.Byte[],System.String,System.String)">
+        <member name="M:JsInterop.SetImageAsync(Microsoft.JSInterop.IJSRuntime,System.Byte[],System.String,System.String)">
             <summary>
-            set html img element to display the image
-            this function is the preferred way to display the crop result in dotnet 6
+                set html img element to display the image
+                this function is the preferred way to display the crop result in dotnet 6
             </summary>
             <param name="js"></param>
             <param name="bin">image bytes</param>
@@ -234,42 +252,42 @@
             <param name="format">like image/jpg</param>
             <returns></returns>
         </member>
-        <member name="T:Blazor.Cropper.StreamFile">
+        <member name="T:StreamFile">
             <summary>
-            mock a browserfile from a stream
+                mock a browserfile from a stream
             </summary>
         </member>
-        <member name="M:Blazor.Cropper.StreamFile.#ctor(System.IO.Stream,System.String,System.String)">
+        <member name="M:StreamFile.#ctor(System.IO.Stream,System.String,System.String)">
             <summary>
-            Build a stream file
+                Build a stream file
             </summary>
             <param name="stream"></param>
             <param name="name"></param>
             <param name="contentType"></param>
         </member>
-        <member name="P:Blazor.Cropper.StreamFile.Name">
+        <member name="P:StreamFile.Name">
             <summary>
-            name
+                name
             </summary>
         </member>
-        <member name="P:Blazor.Cropper.StreamFile.LastModified">
+        <member name="P:StreamFile.LastModified">
             <summary>
-            not impl
+                not impl
             </summary>
         </member>
-        <member name="P:Blazor.Cropper.StreamFile.Size">
+        <member name="P:StreamFile.Size">
             <summary>
-            stream size
+                stream size
             </summary>
         </member>
-        <member name="P:Blazor.Cropper.StreamFile.ContentType">
+        <member name="P:StreamFile.ContentType">
             <summary>
-            content type, should in form of image/xxx
+                content type, should in form of image/xxx
             </summary>
         </member>
-        <member name="M:Blazor.Cropper.StreamFile.OpenReadStream(System.Int64,System.Threading.CancellationToken)">
+        <member name="M:StreamFile.OpenReadStream(System.Int64,System.Threading.CancellationToken)">
             <summary>
-            open read stream
+                open read stream
             </summary>
             <param name="maxAllowedSize"></param>
             <param name="cancellationToken"></param>

--- a/Blazor.Cropper/Blazor.Cropper/Blazor.Cropper.xml
+++ b/Blazor.Cropper/Blazor.Cropper/Blazor.Cropper.xml
@@ -230,7 +230,7 @@
             </summary>
             <param name="js"></param>
             <param name="bin">image bytes</param>
-            <param name="imgid">img element id</param>
+            <param name="imgId">img element id</param>
             <param name="format">like image/jpg</param>
             <returns></returns>
         </member>

--- a/Blazor.Cropper/CropBox.cs
+++ b/Blazor.Cropper/CropBox.cs
@@ -148,15 +148,25 @@ internal class CropBox
         {
             H = _minposY + _imgh - Y;
             W = _requestRatio ? H / _ratio : W;
-            if (Y - _unsavedY < 0) Y = _unsavedY - (H - _unsavedH);
-            if (X - _unsavedX < 0) X = _unsavedX - (W - _unsavedW);
+            if (Y - _unsavedY < 0)
+            {
+                Y = _unsavedY - (H - _unsavedH);
+            }
+
+            if (X - _unsavedX < 0)
+            {
+                X = _unsavedX - (W - _unsavedW);
+            }
         }
 
         if (X + W > _minposX + _imgw)
         {
             W = _minposX + _imgw - X;
             H = _requestRatio ? W * _ratio : H;
-            if (Y - _unsavedY < 0) Y = _unsavedY - (H - _unsavedH);
+            if (Y - _unsavedY < 0)
+            {
+                Y = _unsavedY - (H - _unsavedH);
+            }
         }
     }
 

--- a/Blazor.Cropper/CropBox.cs
+++ b/Blazor.Cropper/CropBox.cs
@@ -1,171 +1,174 @@
 using System;
 using System.Collections.Generic;
 
-namespace Blazor.Cropper
+namespace Blazor.Cropper;
+
+internal class CropBox
 {
-    class CropBox
+    private readonly Cropper _cropper;
+
+    internal CropBox(Cropper cropper)
     {
-        public double X { get; private set; }
-        public double Y { get; private set; }
-        public double H { get; private set; }
-        public double W { get; private set; }
+        X = cropper._prevPosX;
+        Y = cropper._prevPosY;
+        H = cropper.initCropHeight;
+        W = cropper.initCropWidth;
+        _cropper = cropper;
+    }
 
-        private double _initX => _cropper._prevPosX;
-        private double _initY => _cropper._prevPosY;
-        private double _initW => _cropper.initCropWidth;
-        private double _initH => _cropper.initCropHeight;
-        private double _ratio => _cropper.AspectRatio;
-        private double _imgh => _cropper._imgh;
-        private double _imgw => _cropper._imgw;
-        private double _unsavedX => _cropper._unsavedX;
-        private double _unsavedY => _cropper._unsavedY;
-        private double _unsavedW => _cropper._unsavedCropW;
-        private double _unsavedH => _cropper._unsavedCropH;
-        private double _minval => _cropper._minval;
-        private bool _requestRatio => _cropper.RequireAspectRatio;
-        private Cropper _cropper;
+    public double X { get; private set; }
+    public double Y { get; private set; }
+    public double H { get; private set; }
+    public double W { get; private set; }
 
-        private double _minposX => _cropper._minposX;
-        private double _minposY => _cropper._minposY;
-        private double _minvalx => _cropper._minvalx;
-        private double _minvaly => _cropper._minvaly;
+    private double _initX => _cropper._prevPosX;
+    private double _initY => _cropper._prevPosY;
+    private double _initW => _cropper.initCropWidth;
+    private double _initH => _cropper.initCropHeight;
+    private double _ratio => _cropper.AspectRatio;
+    private double _imgh => _cropper._imgh;
+    private double _imgw => _cropper._imgw;
+    private double _unsavedX => _cropper._unsavedX;
+    private double _unsavedY => _cropper._unsavedY;
+    private double _unsavedW => _cropper._unsavedCropW;
+    private double _unsavedH => _cropper._unsavedCropH;
+    private double _minval => _cropper._minval;
+    private bool _requestRatio => _cropper.RequireAspectRatio;
 
-        internal CropBox(Cropper cropper)
+    private double _minposX => _cropper._minposX;
+    private double _minposY => _cropper._minposY;
+    private double _minvalx => _cropper._minvalx;
+    private double _minvaly => _cropper._minvaly;
+
+    private void xxLeft(double deltaX, double deltaY, MoveDir dir)
+    {
+        H = _initH +
+            (dir == MoveDir.UpLeft ? -deltaY : deltaY);
+        W = _initW - deltaX;
+        if (_requestRatio)
         {
-            X = cropper._prevPosX;
-            Y = cropper._prevPosY;
-            H = cropper.initCropHeight;
-            W = cropper.initCropWidth;
-            _cropper = cropper;
+            W = H / _ratio;
+            deltaX = _initW - W;
         }
-        void xxLeft(double deltaX, double deltaY, MoveDir dir)
+
+        X = _initX + deltaX;
+    }
+
+    internal void DragCorner(double deltaX, double deltaY, MoveDir dir)
+    {
+        Dictionary<MoveDir, Action> funcdic = new Dictionary<MoveDir, Action>
         {
-            H = _initH +
-                ((dir == MoveDir.UpLeft) ? (-deltaY) : deltaY);
-            W = _initW - deltaX;
-            if (_requestRatio)
             {
-                W = H / _ratio;
-                deltaX = _initW - W;
-            }
-            X = _initX + deltaX;
-        }
-        internal void DragCorner(double deltaX, double deltaY, MoveDir dir)
-        {
-            var funcdic = new Dictionary<MoveDir, Action>()
-            {
-                { MoveDir.Up, () =>
+                MoveDir.Up, () =>
                 {
                     Y = _initY + deltaY;
                     H = _initH - deltaY;
-                } },
-                { MoveDir.Down, () => H = _initH + deltaY },
-                { MoveDir.Left, () =>
+                }
+            },
+            { MoveDir.Down, () => H = _initH + deltaY },
+            {
+                MoveDir.Left, () =>
                 {
                     X = _initX + deltaX;
                     W = _initW - deltaX;
-                } },
-                { MoveDir.Right, () => W = _initW + deltaX },
-                { MoveDir.UpLeft, () =>
+                }
+            },
+            { MoveDir.Right, () => W = _initW + deltaX },
+            {
+                MoveDir.UpLeft, () =>
                 {
                     Y = _initY + deltaY;
                     xxLeft(deltaX, deltaY, dir);
-                } },
-                { MoveDir.UpRight, () =>
+                }
+            },
+            {
+                MoveDir.UpRight, () =>
                 {
                     Y = _initY + deltaY;
                     H = _initH - deltaY;
                     W = _initW + deltaX;
-                } },
-                { MoveDir.DownLeft, () => xxLeft(deltaX, deltaY, dir) },
-                { MoveDir.DownRight, () =>
+                }
+            },
+            { MoveDir.DownLeft, () => xxLeft(deltaX, deltaY, dir) },
+            {
+                MoveDir.DownRight, () =>
                 {
                     H = _initH + deltaY;
                     W = _initW + deltaX;
-                } },
+                }
+            }
+        };
+        funcdic[dir]();
+        AdjustWH(dir);
+        CheckOutOfBox();
+        CheckMinWH();
+    }
+
+    internal void AdjustWH(MoveDir dir)
+    {
+        if (_requestRatio)
+            _ = dir switch
+            {
+                MoveDir.Left or MoveDir.Right =>
+                    H = W * _ratio,
+                MoveDir.UpLeft or MoveDir.DownLeft => 0,
+                MoveDir.UnKnown => throw new NotImplementedException(),
+                _ => W = H / _ratio
             };
-            funcdic[dir]();
-            AdjustWH(dir);
-            CheckOutOfBox();
-            CheckMinWH();
-        }
-        internal void AdjustWH(MoveDir dir)
+    }
+
+    internal void CheckOutOfBox()
+    {
+        if (Y < _minposY)
         {
-            if (_requestRatio)
-            {
-                _ = dir switch
-                {
-                    MoveDir.Left or MoveDir.Right =>
-                        H = W * _ratio,
-                    MoveDir.UpLeft or MoveDir.DownLeft => 0,
-                    MoveDir.UnKnown => throw new NotImplementedException(),
-                    _ => W = H / _ratio
-                };
-            }
+            double ydelta = Y - _minposY;
+            Y = _minposY;
+            H += ydelta;
+            W = _requestRatio ? H / _ratio : W;
+            if (X - _unsavedX < 0) X = _unsavedX - (W - _unsavedW);
         }
-        internal void CheckOutOfBox()
+
+        if (X < _minposX)
         {
-            if (Y < _minposY)
-            {
-                var ydelta = Y - _minposY;
-                Y = _minposY;
-                H += ydelta;
-                W = _requestRatio? H / _ratio : W;
-                if (X-_unsavedX<0)
-                {
-                    X = _unsavedX - (W-_unsavedW);   
-                }
-            }
-            if (X < _minposX)
-            {
-                var xdelta = X - _minposX;
-                X = _minposX;
-                W += xdelta;
-                H = _requestRatio? W * _ratio : H;
-                if (Y-_unsavedY<0)
-                {
-                    Y = _unsavedY - (H-_unsavedH);
-                }
-            }
-            if (Y + H > (_minposY + _imgh))
-            {
-                H = (_minposY + _imgh) - Y;
-                W = _requestRatio? H / _ratio : W;
-                if (Y-_unsavedY<0)
-                {
-                    Y = _unsavedY - (H-_unsavedH);
-                }
-                if (X-_unsavedX<0)
-                {
-                    X = _unsavedX - (W-_unsavedW);   
-                }
-            }
-            if (X + W > (_minposX + _imgw))
-            {
-                W = (_minposX + _imgw) - X;
-                H = _requestRatio? W * _ratio : H;
-                if (Y-_unsavedY<0)
-                {
-                    Y = _unsavedY - (H-_unsavedH);
-                }
-            }
+            double xdelta = X - _minposX;
+            X = _minposX;
+            W += xdelta;
+            H = _requestRatio ? W * _ratio : H;
+            if (Y - _unsavedY < 0) Y = _unsavedY - (H - _unsavedH);
         }
-        internal void CheckMinWH()
+
+        if (Y + H > _minposY + _imgh)
         {
-            if (H < _minvaly)
-            {
-                H = _unsavedH;
-                Y = _unsavedY;
-                W = _unsavedW;
-                X = _unsavedX;
-            }
-            if (W < _minvalx)
-            {
-                W = _unsavedW;
-                X = _unsavedX;
-                H = _unsavedH;
-                Y = _unsavedY;
-            }
+            H = _minposY + _imgh - Y;
+            W = _requestRatio ? H / _ratio : W;
+            if (Y - _unsavedY < 0) Y = _unsavedY - (H - _unsavedH);
+            if (X - _unsavedX < 0) X = _unsavedX - (W - _unsavedW);
+        }
+
+        if (X + W > _minposX + _imgw)
+        {
+            W = _minposX + _imgw - X;
+            H = _requestRatio ? W * _ratio : H;
+            if (Y - _unsavedY < 0) Y = _unsavedY - (H - _unsavedH);
+        }
+    }
+
+    internal void CheckMinWH()
+    {
+        if (H < _minvaly)
+        {
+            H = _unsavedH;
+            Y = _unsavedY;
+            W = _unsavedW;
+            X = _unsavedX;
+        }
+
+        if (W < _minvalx)
+        {
+            W = _unsavedW;
+            X = _unsavedX;
+            H = _unsavedH;
+            Y = _unsavedY;
         }
     }
 }

--- a/Blazor.Cropper/CropBox.cs
+++ b/Blazor.Cropper/CropBox.cs
@@ -107,14 +107,15 @@ internal class CropBox
     internal void AdjustWH(MoveDir dir)
     {
         if (_requestRatio)
+        {
             _ = dir switch
             {
-                MoveDir.Left or MoveDir.Right =>
-                    H = W * _ratio,
+                MoveDir.Left or MoveDir.Right => H = W * _ratio,
                 MoveDir.UpLeft or MoveDir.DownLeft => 0,
                 MoveDir.UnKnown => throw new NotImplementedException(),
                 _ => W = H / _ratio
             };
+        }
     }
 
     internal void CheckOutOfBox()
@@ -125,7 +126,10 @@ internal class CropBox
             Y = _minposY;
             H += ydelta;
             W = _requestRatio ? H / _ratio : W;
-            if (X - _unsavedX < 0) X = _unsavedX - (W - _unsavedW);
+            if (X - _unsavedX < 0)
+            {
+                X = _unsavedX - (W - _unsavedW);
+            }
         }
 
         if (X < _minposX)
@@ -134,7 +138,10 @@ internal class CropBox
             X = _minposX;
             W += xdelta;
             H = _requestRatio ? W * _ratio : H;
-            if (Y - _unsavedY < 0) Y = _unsavedY - (H - _unsavedH);
+            if (Y - _unsavedY < 0)
+            {
+                Y = _unsavedY - (H - _unsavedH);
+            }
         }
 
         if (Y + H > _minposY + _imgh)

--- a/Blazor.Cropper/CropBox.cs
+++ b/Blazor.Cropper/CropBox.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using Blazor.Cropper;
 
-namespace Blazor.Cropper;
 
 internal class CropBox
 {

--- a/Blazor.Cropper/CropInfo.cs
+++ b/Blazor.Cropper/CropInfo.cs
@@ -1,6 +1,5 @@
 ﻿using SixLabors.ImageSharp;
 
-namespace Blazor.Cropper;
 
 /// <summary>
 ///     Crop metadata

--- a/Blazor.Cropper/CropInfo.cs
+++ b/Blazor.Cropper/CropInfo.cs
@@ -1,37 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using SixLabors.ImageSharp;
+﻿using SixLabors.ImageSharp;
 
-namespace Blazor.Cropper
+namespace Blazor.Cropper;
+
+/// <summary>
+///     Crop metadata
+/// </summary>
+public class CropInfo
 {
     /// <summary>
-    /// Crop metadata
+    ///     Crop zone in pixel (for original image)
     /// </summary>
-    public class CropInfo
-    {
-        /// <summary>
-        /// Crop zone in pixel (for original image)
-        /// </summary>
-        public Rectangle Rectangle { get; init; }
-        /// <summary>
-        /// ratio
-        /// </summary>
-        public double Ratio { get; init; }
-        /// <summary>
-        /// resizeprop
-        /// </summary>
-        public double ResizeProp { get; init; }
-        /// <summary>
-        /// Get init parameters from this function to restore the cropper state
-        /// note that the data returned from this function is in physical pixel
-        /// </summary>
-        /// <returns></returns>
-        public (int offsetX,int offsetY, int initX,int initY,double ratio) GetInitParams()
-        {
-            return ((int)(Rectangle.X / ResizeProp), (int)(Rectangle.Y / ResizeProp), (int)(Rectangle.Width / ResizeProp), (int)(Rectangle.Height / ResizeProp), Ratio);
-        } 
-    }
+    public Rectangle Rectangle { get; init; }
+
+    /// <summary>
+    ///     ratio
+    /// </summary>
+    public double Ratio { get; init; }
+
+    /// <summary>
+    ///     resizeprop
+    /// </summary>
+    public double ResizeProp { get; init; }
+
+    /// <summary>
+    ///     Get init parameters from this function to restore the cropper state
+    ///     note that the data returned from this function is in physical pixel
+    /// </summary>
+    /// <returns></returns>
+    public (int offsetX, int offsetY, int initX, int initY, double ratio) GetInitParams()
+        => ((int)(Rectangle.X / ResizeProp), (int)(Rectangle.Y / ResizeProp), (int)(Rectangle.Width / ResizeProp),
+            (int)(Rectangle.Height / ResizeProp), Ratio);
 }

--- a/Blazor.Cropper/Cropper.razor
+++ b/Blazor.Cropper/Cropper.razor
@@ -1,155 +1,137 @@
 ﻿<div class="image-list">
-<div id="blazor_cropper" class="image-list unSelectAble" style="@(RatioStyle+ImglistStyle)" >
-    <img id="oriimg" class="imgbac" draggable="false" src="" style="@(BackgroundImgStyle)"
-        @ontouchend="(args)=>{
-                 if(_onTwoFingerResizing||_isBacMoving)
-                 {
-                     _isBacMoving = false;
-                     _onTwoFingerResizing=false;
-                     InitBox();
-                 }
-             }"
-        @ontouchmove:stopPropagation
-        @ontouchstart:stopPropagation
-        @ontouchmove="OnResizeBackGroundImage"
-        @ontouchstart="args=>{
-                   _prevBacX = args.Touches[0].ClientX;
-                   _prevBacY = args.Touches[0].ClientY;
-                   _isBacMoving = true;
-               }"
-        @onmousedown="args=>{
-                  _prevBacX = args.ClientX;
-                  _prevBacY = args.ClientY;
-                  _isBacMoving = true;
-              }"/>
-    <div draggable="false" id="mainBox" @ontouchstart:stopPropagation
-        @ontouchend="OnSizeChangeEnd"
-        style="@_cropperStyle">
-        <div id="left-up" class="minBox left-up" @ontouchstart="args=> TouchToMouse(args,arg=>OnResizeStart(arg,MoveDir.UpLeft))" @onmousedown="args=> OnResizeStart(args,MoveDir.UpLeft)"></div>
-        <div id="up" class="minBox up" @ontouchstart="args=> TouchToMouse(args,arg=>OnResizeStart(arg,MoveDir.Up))" @onmousedown="args=> OnResizeStart(args,MoveDir.Up)"></div>
-        <div id="right-up" class="minBox right-up" @ontouchstart="args=> TouchToMouse(args,arg=>OnResizeStart(arg,MoveDir.UpRight))" @onmousedown="args=> OnResizeStart(args,MoveDir.UpRight)"></div>
-        <div id="left" class="minBox left" @onmousedown="args=> OnResizeStart(args,MoveDir.Left)" @ontouchstart="args=> TouchToMouse(args,arg=>OnResizeStart(arg,MoveDir.Left))"></div>
-        <div id="right" class="minBox right" @onmousedown="args=> OnResizeStart(args,MoveDir.Right)" @ontouchstart="args=> TouchToMouse(args,arg=>OnResizeStart(arg,MoveDir.Right))"></div>
-        <div id="left-down" class="minBox left-down" @onmousedown="args=> OnResizeStart(args,MoveDir.DownLeft)" @ontouchstart="args=> TouchToMouse(args,arg=>OnResizeStart(arg,MoveDir.DownLeft))"></div>
-        <div id="down" class="minBox down" @onmousedown="args=> OnResizeStart(args,MoveDir.Down)" @ontouchstart="args=> TouchToMouse(args,arg=>OnResizeStart(arg,MoveDir.Down))"></div>
-        <div id="right-down" class="minBox right-down" @onmousedown="args=> OnResizeStart(args,MoveDir.DownRight)" @ontouchstart="args=> TouchToMouse(args,arg=>OnResizeStart(arg,MoveDir.DownRight))"></div>
+    <div id="blazor_cropper" class="image-list unSelectAble" style="@(RatioStyle + ImglistStyle)">
+        <img id="oriimg" class="imgbac" draggable="false" src="" style="@(BackgroundImgStyle)"
+             @ontouchend="args =>{ if (_onTwoFingerResizing || _isBacMoving) { _isBacMoving = false; _onTwoFingerResizing = false; InitBox(); } }"
+             @ontouchmove:stopPropagation
+             @ontouchstart:stopPropagation
+             @ontouchmove="OnResizeBackGroundImage"
+             @ontouchstart="args =>{ _prevBacX = args.Touches[0].ClientX; _prevBacY = args.Touches[0].ClientY; _isBacMoving = true; }"
+             @onmousedown="args =>{ _prevBacX = args.ClientX; _prevBacY = args.ClientY; _isBacMoving = true; }"/>
+        <div draggable="false" id="mainBox" @ontouchstart:stopPropagation
+                                            @ontouchend="OnSizeChangeEnd"
+             style="@_cropperStyle">
+            <div id="left-up" class="minBox left-up" @ontouchstart="args => TouchToMouse(args, arg => OnResizeStart(arg, MoveDir.UpLeft))" @onmousedown="args => OnResizeStart(args, MoveDir.UpLeft)"></div>
+            <div id="up" class="minBox up" @ontouchstart="args => TouchToMouse(args, arg => OnResizeStart(arg, MoveDir.Up))" @onmousedown="args => OnResizeStart(args, MoveDir.Up)"></div>
+            <div id="right-up" class="minBox right-up" @ontouchstart="args => TouchToMouse(args, arg => OnResizeStart(arg, MoveDir.UpRight))" @onmousedown="args => OnResizeStart(args, MoveDir.UpRight)"></div>
+            <div id="left" class="minBox left" @onmousedown="args => OnResizeStart(args, MoveDir.Left)" @ontouchstart="args => TouchToMouse(args, arg => OnResizeStart(arg, MoveDir.Left))"></div>
+            <div id="right" class="minBox right" @onmousedown="args => OnResizeStart(args, MoveDir.Right)" @ontouchstart="args => TouchToMouse(args, arg => OnResizeStart(arg, MoveDir.Right))"></div>
+            <div id="left-down" class="minBox left-down" @onmousedown="args => OnResizeStart(args, MoveDir.DownLeft)" @ontouchstart="args => TouchToMouse(args, arg => OnResizeStart(arg, MoveDir.DownLeft))"></div>
+            <div id="down" class="minBox down" @onmousedown="args => OnResizeStart(args, MoveDir.Down)" @ontouchstart="args => TouchToMouse(args, arg => OnResizeStart(arg, MoveDir.Down))"></div>
+            <div id="right-down" class="minBox right-down" @onmousedown="args => OnResizeStart(args, MoveDir.DownRight)" @ontouchstart="args => TouchToMouse(args, arg => OnResizeStart(arg, MoveDir.DownRight))"></div>
+        </div>
+        <img id="dimg" @onmousedown="OnDragStart" @ontouchstart="args => TouchToMouse(args, OnDragStart)"
+             @ontouchend="OnDragEnd"
+             class="img" draggable="false" style="@(BackgroundImgStyle + _cropedImgStyle)" src="" @ontouchstart:stopPropagation/>
     </div>
-    <img id="dimg" @onmousedown="OnDragStart" @ontouchstart="args=> TouchToMouse(args,OnDragStart)"
-        @ontouchend="OnDragEnd"
-        class="img" draggable="false"  style="@(BackgroundImgStyle+_cropedImgStyle)" src="" @ontouchstart:stopPropagation />
-</div>
 </div>
 
 <style>
-.unSelectAble{
-    -webkit-user-select: none;
-    -khtml-user-select: none;
-    -moz-user-select: none;
-    -o-user-select: none;
-    user-select: none;
-    touch-action: none;
-    -ms-touch-action: none;
-}
-
-.image-list{
-    position: relative;
-    background-color: grey;
-    overflow: auto;
-    scrollbar-width: none;
-}
-
-.image-list::-webkit-scrollbar {
-    display: none;
-}
-
-.imgbac{
-    opacity: 0.5;
-    position: absolute;
-    object-fit: contain;
-    width: 100%;
-    height: 100%;
-
-}
-.img{
-    position: absolute;
-    clip: rect(0, 150px, 150px, 0);
-    cursor: move;
-    object-fit: contain;
-    width: 100%;
-    height: 100%;
-}
-#mainBox {
-    border: 1px solid white;
-    position: absolute;
-    width: 150px;
-    height: 150px;
-    cursor: move!important;
-}
-
-.minBox {
-    position: absolute;
-    height: 12px;
-    width: 12px;
-    background-color: white;
-}
-
-.left-up {
-    top: -6px;
-    left: -6px;
-    cursor: nw-resize;
-}
-
-.up {
-    left: 50%;
-    margin-left: -6px;
-    top: -6px;
-    cursor: n-resize;
-}
-
-.right-up {
-    right: -6px;
-    top: -6px;
-    cursor: ne-resize;
-}
-
-.left {
-    top: 50%;
-    margin-top: -6px;
-    left: -6px;
-    cursor: w-resize;
-}
-
-.right {
-    top: 50%;
-    margin-top: -6px;
-    right: -6px;
-    cursor: e-resize;
-}
-
-.left-down {
-    bottom: -6px;
-    left: -6px;
-    cursor: sw-resize;
-}
-
-.down {
-    bottom: -6px;
-    left: 50%;
-    margin-left: -6px;
-    cursor: s-resize;
-}
-
-.right-down {
-    bottom: -6px;
-    right: -6px;
-    cursor: se-resize;
-}
-@@media screen and (max-width: 1080px) {
-    .right-down,.left-down,.left-up,.right-up{
-        z-index: 99;
+    .unSelectAble {
+        -khtml-user-select: none;
+        -moz-user-select: none;
+        -ms-touch-action: none;
+        -o-user-select: none;
+        -webkit-user-select: none;
+        touch-action: none;
+        user-select: none;
     }
-    .right,.left,.down,.up{
-        display: none;
+
+    .image-list {
+        background-color: grey;
+        overflow: auto;
+        position: relative;
+        scrollbar-width: none;
     }
-}
+
+    .image-list::-webkit-scrollbar { display: none; }
+
+    .imgbac {
+        height: 100%;
+        object-fit: contain;
+        opacity: 0.5;
+        position: absolute;
+        width: 100%;
+    }
+
+    .img {
+        clip: rect(0, 150px, 150px, 0);
+        cursor: move;
+        height: 100%;
+        object-fit: contain;
+        position: absolute;
+        width: 100%;
+    }
+
+    #mainBox {
+        border: 1px solid white;
+        cursor: move !important;
+        height: 150px;
+        position: absolute;
+        width: 150px;
+    }
+
+    .minBox {
+        background-color: white;
+        height: 12px;
+        position: absolute;
+        width: 12px;
+    }
+
+    .left-up {
+        cursor: nw-resize;
+        left: -6px;
+        top: -6px;
+    }
+
+    .up {
+        cursor: n-resize;
+        left: 50%;
+        margin-left: -6px;
+        top: -6px;
+    }
+
+    .right-up {
+        cursor: ne-resize;
+        right: -6px;
+        top: -6px;
+    }
+
+    .left {
+        cursor: w-resize;
+        left: -6px;
+        margin-top: -6px;
+        top: 50%;
+    }
+
+    .right {
+        cursor: e-resize;
+        margin-top: -6px;
+        right: -6px;
+        top: 50%;
+    }
+
+    .left-down {
+        bottom: -6px;
+        cursor: sw-resize;
+        left: -6px;
+    }
+
+    .down {
+        bottom: -6px;
+        cursor: s-resize;
+        left: 50%;
+        margin-left: -6px;
+    }
+
+    .right-down {
+        bottom: -6px;
+        cursor: se-resize;
+        right: -6px;
+    }
+
+    @@media screen and (max-width: 1080px) {
+        .right-down, .left-down, .left-up, .right-up { z-index: 99; }
+
+        .right, .left, .down, .up { display: none; }
+    }
 </style>

--- a/Blazor.Cropper/Cropper.razor.cs
+++ b/Blazor.Cropper/Cropper.razor.cs
@@ -11,866 +11,879 @@ using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Processing;
 
-namespace Blazor.Cropper;
-
-/// <summary>
-///     Cropper component
-/// </summary>
-public partial class Cropper : IAsyncDisposable
+namespace Blazor.Cropper
 {
-    [Inject] internal IJSRuntime JsRuntime { get; set; }
-
-    #region params
-
     /// <summary>
-    ///     whether use c# for ordinary img processing
+    ///     Cropper component
     /// </summary>
-    /// <value>default: false</value>
-    [Parameter]
-    public bool PureCSharpProcessing { get; set; } = false;
-
-    /// <summary>
-    ///     If this property is true, the image will become
-    ///     unresizable in cropper
-    /// </summary>
-    /// <value>default: true</value>
-    [Parameter]
-    public bool IsImageLocked { get; set; } = true;
-
-    /// <summary>
-    ///     the initial width of cropper if possible.
-    ///     shall not be smaller than 30.
-    /// </summary>
-    /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
-    /// <value>default: 150</value>
-    [Parameter]
-    public double InitCropWidth { get; set; } = 150;
-
-    internal double initCropWidth = -1;
-
-    /// <summary>
-    ///     the initial height of cropper if possible.
-    ///     shall not be smaller than 30.
-    /// </summary>
-    /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
-    /// <value>default: 150</value>
-    [Parameter]
-    public double InitCropHeight { get; set; } = 150;
-
-    internal double initCropHeight = -1;
-
-    /// <summary>
-    ///     sepecify whether the cropper's aspect ratio is fixed
-    /// </summary>
-    /// <value>default: false</value>
-    [Parameter]
-    public bool RequireAspectRatio { get; set; } = false;
-
-    /// <summary>
-    ///     sepecify the cropper's aspect ratio
-    /// </summary>
-    /// <remarks>
-    ///     Only works when <see cref="RequireAspectRatio" />
-    ///     is true
-    /// </remarks>
-    /// <value>default: 1</value>
-    [Parameter]
-    public double AspectRatio { get; set; } = 1;
-
-    /// <summary>
-    ///     The input image file. Usually get from an
-    ///     <see cref="InputFile" /> Component. You can also
-    ///     mock a file from stream using <see cref="StreamFile" /> if needed.
-    /// </summary>
-    /// <value></value>
-    [Parameter]
-    public IBrowserFile ImageFile { get; set; }
-
-    /// <summary>
-    ///     Fire when the image file load into cropper
-    /// </summary>
-    /// <value></value>
-    [Parameter]
-    public EventCallback OnLoad { get; set; }
-
-    /// <summary>
-    ///     Set whether the anime gif crop is enabled. If enabled,
-    ///     the gif file smaller than 1mb would
-    ///     be cropped as animed image. If disabled, only the first
-    ///     frame would be cropped.
-    /// </summary>
-    /// <remarks>
-    ///     Crop large gif image can cause the window stop responding
-    ///     for half a minute!
-    /// </remarks>
-    /// <value>default: true</value>
-    [Parameter]
-    public bool AnimeGifEnable { get; set; } = true;
-
-    /// <summary>
-    ///     The input element's id value. This param is optional and
-    ///     can help cropper to init image
-    ///     faster on browser before dotnet core version 6.
-    ///     Does't have effect if <see cref="PureCSharpProcessing" /> is true.
-    /// </summary>
-    [Parameter]
-    public string InputId { get; set; }
-
-    /// <summary>
-    ///     Max allowed crop result height. Should not be larger than 500.
-    /// </summary>
-    /// <value>default:500</value>
-    [Parameter]
-    public double MaxCropedHeight { get; set; } = 500;
-
-    /// <summary>
-    ///     Max allowed crop result width. Should not be larger than 500.
-    /// </summary>
-    /// <value>default:500</value>
-    [Parameter]
-    public double MaxCropedWidth { get; set; } = 500;
-
-    /// <summary>
-    ///     Height of this component in px
-    /// </summary>
-    /// <value>default:150</value>
-    [Parameter]
-    public double CropperHeight { get; set; } = 150;
-
-    /// <summary>
-    ///     Whether the cropper size is locked
-    /// </summary>
-    /// <value>default: false</value>
-    [Parameter]
-    public bool IsCropLocked { get; set; } = false;
-
-    /// <summary>
-    ///     The scaling ratio, should be bind two way.
-    /// </summary>
-    /// <value>default: 1.0</value>
-    [Parameter]
-    public double Ratio
+    public partial class Cropper : IAsyncDisposable
     {
-        get => _ratio;
-        set
+        [Inject] internal IJSRuntime JsRuntime { get; set; }
+
+        #region params
+
+        /// whether use c# for ordinary img processing
+        [Parameter]
+        public double FinalCropHeight { get; set; }
+
+        /// whether use c# for ordinary img processing
+        [Parameter]
+        public double FinalCropWidth { get; set; }
+
+        /// <summary>
+        ///     whether use c# for ordinary img processing
+        /// </summary>
+        /// <value>default: false</value>
+        [Parameter]
+        public bool PureCSharpProcessing { get; set; } = false;
+
+        /// <summary>
+        ///     If this property is true, the image will become
+        ///     unresizable in cropper
+        /// </summary>
+        /// <value>default: true</value>
+        [Parameter]
+        public bool IsImageLocked { get; set; } = true;
+
+        /// <summary>
+        ///     the initial width of cropper if possible.
+        ///     shall not be smaller than 30.
+        /// </summary>
+        /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
+        /// <value>default: 150</value>
+        [Parameter]
+        public double InitCropWidth { get; set; } = 150;
+
+        internal double initCropWidth = -1;
+
+        /// <summary>
+        ///     the initial height of cropper if possible.
+        ///     shall not be smaller than 30.
+        /// </summary>
+        /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
+        /// <value>default: 150</value>
+        [Parameter]
+        public double InitCropHeight { get; set; } = 150;
+
+        internal double initCropHeight = -1;
+
+        /// <summary>
+        ///     sepecify whether the cropper's aspect ratio is fixed
+        /// </summary>
+        /// <value>default: false</value>
+        [Parameter]
+        public bool RequireAspectRatio { get; set; } = false;
+
+        /// <summary>
+        ///     sepecify the cropper's aspect ratio
+        /// </summary>
+        /// <remarks>
+        ///     Only works when <see cref="RequireAspectRatio" />
+        ///     is true
+        /// </remarks>
+        /// <value>default: 1</value>
+        [Parameter]
+        public double AspectRatio { get; set; } = 1;
+
+        /// <summary>
+        ///     The input image file. Usually get from an
+        ///     <see cref="InputFile" /> Component. You can also
+        ///     mock a file from stream using <see cref="StreamFile" /> if needed.
+        /// </summary>
+        /// <value></value>
+        [Parameter]
+        public IBrowserFile ImageFile { get; set; }
+
+        /// <summary>
+        ///     Fire when the image file load into cropper
+        /// </summary>
+        /// <value></value>
+        [Parameter]
+        public EventCallback OnLoad { get; set; }
+
+        /// <summary>
+        ///     Set whether the anime gif crop is enabled. If enabled,
+        ///     the gif file smaller than 1mb would
+        ///     be cropped as animed image. If disabled, only the first
+        ///     frame would be cropped.
+        /// </summary>
+        /// <remarks>
+        ///     Crop large gif image can cause the window stop responding
+        ///     for half a minute!
+        /// </remarks>
+        /// <value>default: true</value>
+        [Parameter]
+        public bool AnimeGifEnable { get; set; } = true;
+
+        /// <summary>
+        ///     The input element's id value. This param is optional and
+        ///     can help cropper to init image
+        ///     faster on browser before dotnet core version 6.
+        ///     Does't have effect if <see cref="PureCSharpProcessing" /> is true.
+        /// </summary>
+        [Parameter]
+        public string InputId { get; set; }
+
+        /// <summary>
+        ///     Max allowed crop result height. Should not be larger than 500.
+        /// </summary>
+        /// <value>default:500</value>
+        [Parameter]
+        public double MaxCropedHeight { get; set; } = 500;
+
+        /// <summary>
+        ///     Max allowed crop result width. Should not be larger than 500.
+        /// </summary>
+        /// <value>default:500</value>
+        [Parameter]
+        public double MaxCropedWidth { get; set; } = 500;
+
+        /// <summary>
+        ///     Height of this component in px
+        /// </summary>
+        /// <value>default:150</value>
+        [Parameter]
+        public double CropperHeight { get; set; } = 150;
+
+        /// <summary>
+        ///     Whether the cropper size is locked
+        /// </summary>
+        /// <value>default: false</value>
+        [Parameter]
+        public bool IsCropLocked { get; set; } = false;
+
+        /// <summary>
+        ///     The scaling ratio, should be bind two way.
+        /// </summary>
+        /// <value>default: 1.0</value>
+        [Parameter]
+        public double Ratio
         {
-            if (value == _ratio || IsImageLocked) return;
-
-            _ratio = value;
-            RatioChanged.InvokeAsync(value);
-        }
-    }
-
-    /// <summary>
-    ///     Fire when scaling ratio changed by touch event.
-    /// </summary>
-    [Parameter]
-    public EventCallback<double> RatioChanged { get; set; }
-
-    /// <summary>
-    ///     Fire when cropper size changed.
-    ///     Item1 of the return tuple is width, Item2 is height
-    /// </summary>
-    [Parameter]
-    public EventCallback<(double, double)> OnSizeChanged { get; set; }
-
-    /// <summary>
-    ///     Used to set the cropper initial offset position.
-    /// </summary>
-    /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
-    [Parameter]
-    public double OffsetX { set; get; }
-
-    /// <summary>
-    ///     Used to set the cropper initial offset position.
-    /// </summary>
-    /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
-    [Parameter]
-    public double OffsetY { set; get; }
-
-    /// <summary>
-    ///     Quality of output image. Should be between 0 and 100.
-    ///     Only takes effect when image is in jpg or webp format.
-    /// </summary>
-    /// <value>100</value>
-    [Parameter]
-    public int Quality { set; get; } = 100;
-
-    #endregion
-
-
-    #region public vars
-
-    /// <summary>
-    ///     Min allowed scaling ratio
-    /// </summary>
-    /// <value>1.0</value>
-    public double MinRatio => 1.0;
-
-    /// <summary>
-    ///     Max allowed scaling ratio
-    /// </summary>
-    /// <remarks>This property is obsolete. Max ratio is no longer limited</remarks>
-    /// <value>2</value>
-    [Obsolete("This property is obsolete. Max ratio is no longer limited")]
-    public double MaxRatio => 2.0;
-
-    #endregion
-
-
-    #region internal props
-
-    internal bool WiderThanContainer => _image.Width / _image.Height
-                                        > _imgContainerWidth / _imgContainerHeight;
-
-    internal double ImgRealW
-    {
-        get
-        {
-            if (WiderThanContainer)
-                return _imgContainerWidth * _imgSize / 100;
-            return _imgContainerHeight * _imgSize
-                / 100 * _image.Width / _image.Height;
-        }
-    }
-
-    internal double ImgRealH
-    {
-        get
-        {
-            if (WiderThanContainer)
-                return _imgContainerWidth * _imgSize / 100
-                    * _image.Height / _image.Width;
-            return _imgContainerHeight * _imgSize / 100;
-        }
-    }
-
-    internal string BackgroundImgStyle => FormattableString.Invariant($"left:{_bacx}px;top:{_bacy}px;");
-
-    internal string RatioStyle => FormattableString.Invariant($"transform:scale({Ratio});");
-
-    internal string ImglistStyle => FormattableString.Invariant($"height:{CropperHeight}px;");
-
-    #endregion
-
-
-    #region vars
-
-    internal double _prevBacX = 0;
-    internal double _prevBacY = 0;
-    internal double _bacx = 0;
-    internal double _bacy = 0;
-    internal double _imgSize = 100;
-    internal bool _onTwoFingerResizing = false;
-    internal bool _isBacMoving = false;
-    internal double _prevTouchPointDistance = -1;
-    internal double _imgContainerWidth = 500;
-    internal double _imgContainerHeight = 150;
-    internal double _prevPosX = 0;
-    internal double _prevPosY = 0;
-    internal double _layoutX = 0;
-    internal double _layoutY = 0;
-    internal double _offsetX;
-    internal double _offsetY;
-    internal string _cropperStyle = "";
-    internal string _cropedImgStyle = "clip: rect(0, 150px, 150px, 0);";
-    internal bool _dragging = false;
-    internal bool _reSizing = false;
-    internal MoveDir _dir = MoveDir.UnKnown;
-    internal readonly double _minval = 30;
-    internal ImageData _image;
-    internal double _minposX;
-    internal double _minposY;
-    internal double _imgw;
-    internal double _imgh;
-    internal double _unsavedX;
-    internal double _unsavedY;
-    internal double _unsavedCropW;
-    internal double _unsavedCropH;
-    internal IBrowserFile _prevFile;
-    internal IImageFormat _format;
-    internal Image _gifimage;
-    internal double _ratio = 1d;
-    internal bool _evInitialized = false;
-    internal double _minvalx;
-    internal double _minvaly;
-
-    #endregion
-
-
-    #region static actions
-
-    internal static Action _setaction;
-    internal static Action<MouseEventArgs> _mouseMoveAction;
-    internal static Action<MouseEventArgs> _touchMoveAction;
-    internal static Action _touchEndAction;
-    internal static Action _mouseUpAction;
-
-    #endregion
-
-
-    #region Override methods
-
-    /// <inheritdoc />
-    protected override async Task OnInitializedAsync()
-    {
-        await JsRuntime.InvokeVoidAsync("setVersion", Environment.Version.Major);
-    }
-
-    /// <inheritdoc />
-    protected override void OnParametersSet()
-    {
-        base.OnParametersSet();
-        if (initCropWidth < 0)
-        {
-            initCropWidth = InitCropWidth;
-            initCropHeight = InitCropHeight;
-        }
-    }
-
-    /// <inheritdoc />
-    public async ValueTask DisposeAsync()
-    {
-        await JsRuntime.InvokeVoidAsync("rmCropperEventListeners");
-    }
-
-    private void InitAspectRatio()
-    {
-        _minvalx = _minval;
-        _minvaly = _minval;
-        if (!RequireAspectRatio)
-            return;
-
-        if (initCropHeight > initCropWidth * AspectRatio)
-        {
-            initCropWidth = initCropHeight / AspectRatio;
-            _minvalx = _minvaly / AspectRatio;
-        }
-        else
-        {
-            initCropHeight = initCropWidth * AspectRatio;
-            _minvaly = _minvalx * AspectRatio;
-        }
-
-        SetCropperStyle();
-        SetCroppedImgStyle();
-    }
-
-    /// <inheritdoc />
-    protected override async Task OnParametersSetAsync()
-    {
-        await base.OnParametersSetAsync();
-        InitAspectRatio();
-        if (_prevFile == ImageFile)
-            return;
-        _prevFile = ImageFile;
-        string ext = ImageFile.Name.Split('.').Last().ToLower();
-        IBrowserFile resizedImageFile = ImageFile;
-        await Task.Delay(10);
-        _gifimage?.Dispose();
-        await LoadImage(ext, resizedImageFile);
-        await InitJSAsync();
-        await SetImgContainterSize();
-        await OnLoad.InvokeAsync();
-        await SizeChanged();
-    }
-
-    private async Task InitJSAsync()
-    {
-        double[] data = { 0, 0 };
-        while (data[0] == 0d)
-        {
-            await Task.Delay(10);
-            data = await JsRuntime.InvokeAsync<double[]>("getOriImgSize");
-        }
-
-        _image = new ImageData
-        {
-            Width = data[0],
-            Height = data[1]
-        };
-        if (!_evInitialized)
-        {
-            await JsRuntime.InvokeVoidAsync("addCropperEventListeners");
-            _evInitialized = true;
-        }
-    }
-
-    /// <inheritdoc />
-    protected override async Task OnAfterRenderAsync(bool first)
-    {
-        await base.OnAfterRenderAsync(first);
-        if (first)
-        {
-            _setaction = () => SetImgContainterSize();
-            _mouseMoveAction = args =>
+            get => _ratio;
+            set
             {
-                OnSizeChanging(args);
-                OnResizeBackGroundImage(MouseToTouch(args));
-            };
-            _mouseUpAction = () =>
-            {
-                if (_onTwoFingerResizing || _isBacMoving)
-                {
-                    _isBacMoving = false;
-                    _onTwoFingerResizing = false;
-                    InitBox();
-                }
+                if (value == _ratio || IsImageLocked) return;
 
-                OnSizeChangeEnd();
-            };
-            _touchMoveAction = OnSizeChanging;
-            _touchEndAction = () => { OnSizeChangeEnd(); };
+                _ratio = value;
+                RatioChanged.InvokeAsync(value);
+            }
         }
-    }
 
-    #endregion
+        /// <summary>
+        ///     Fire when scaling ratio changed by touch event.
+        /// </summary>
+        [Parameter]
+        public EventCallback<double> RatioChanged { get; set; }
 
-    #region JsInvokable methods
+        /// <summary>
+        ///     Fire when cropper size changed.
+        ///     Item1 of the return tuple is width, Item2 is height
+        /// </summary>
+        [Parameter]
+        public EventCallback<(double, double)> OnSizeChanged { get; set; }
 
-    [JSInvokable("OnTouchEnd")]
-    public static void TouchEndCaller()
-    {
-        _touchEndAction?.Invoke();
-    }
+        /// <summary>
+        ///     Used to set the cropper initial offset position.
+        /// </summary>
+        /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
+        [Parameter]
+        public double OffsetX { set; get; }
 
-    [JSInvokable("OnTouchMove")]
-    public static void TouchMoveCaller(MouseEventArgs args)
-    {
-        _touchMoveAction?.Invoke(args);
-    }
+        /// <summary>
+        ///     Used to set the cropper initial offset position.
+        /// </summary>
+        /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
+        [Parameter]
+        public double OffsetY { set; get; }
 
-    [JSInvokable("OnMouseUp")]
-    public static void MouseUpCaller()
-    {
-        _mouseUpAction?.Invoke();
-    }
+        /// <summary>
+        ///     Quality of output image. Should be between 0 and 100.
+        ///     Only takes effect when image is in jpg or webp format.
+        /// </summary>
+        /// <value>100</value>
+        [Parameter]
+        public int Quality { set; get; } = 100;
 
-    [JSInvokable("OnMouseMove")]
-    public static void MouseMoveCaller(MouseEventArgs args)
-    {
-        _mouseMoveAction?.Invoke(args);
-    }
-
-    [JSInvokable("SetWidthHeight")]
-    public static void SetWidthHeightCaller()
-    {
-        _setaction?.Invoke();
-    }
-
-    #endregion
+        #endregion
 
 
-    #region Public methods
+        #region public vars
 
-    /// <summary>
-    ///     Get the crop result.
-    /// </summary>
-    /// <returns>crop result</returns>
-    public async Task<ImageCroppedResult> GetCropedResult()
-    {
-        CropInfo info = GetCropInfo();
-        Rectangle rect = info.Rectangle;
-        (int x, int y, int proportionalCropWidth, int proportionalCropHeight, double resizeProp) =
-            (rect.X, rect.Y, rect.Width, rect.Height, info.ResizeProp);
-        if (_gifimage == null)
+        /// <summary>
+        ///     Min allowed scaling ratio
+        /// </summary>
+        /// <value>1.0</value>
+        public double MinRatio => 1.0;
+
+        /// <summary>
+        ///     Max allowed scaling ratio
+        /// </summary>
+        /// <remarks>This property is obsolete. Max ratio is no longer limited</remarks>
+        /// <value>2</value>
+        [Obsolete("This property is obsolete. Max ratio is no longer limited")]
+        public double MaxRatio => 2.0;
+
+        #endregion
+
+
+        #region internal props
+
+        internal bool WiderThanContainer => _image.Width / _image.Height
+                                            > _imgContainerWidth / _imgContainerHeight;
+
+        internal double ImgRealW
         {
-            if (Environment.Version.Major > 5)
+            get
             {
-                // for dotnet version after 5, pass byte array between c# and js is optimized
-                // async function cropAsync(id, sx, sy, swidth, sheight, x, y, width, height, format)
-                byte[] bin = await JsRuntime.InvokeAsync<byte[]>("cropAsync", "oriimg",
-                    x, y, proportionalCropWidth, proportionalCropHeight, 0, 0,
-                    proportionalCropWidth, proportionalCropHeight, _format.DefaultMimeType, Quality);
-                return new ImageCroppedResult(bin, _format);
+                if (WiderThanContainer)
+                    return _imgContainerWidth * _imgSize / 100;
+                return _imgContainerHeight * _imgSize
+                    / 100 * _image.Width / _image.Height;
+            }
+        }
+
+        internal double ImgRealH
+        {
+            get
+            {
+                if (WiderThanContainer)
+                    return _imgContainerWidth * _imgSize / 100
+                        * _image.Height / _image.Width;
+                return _imgContainerHeight * _imgSize / 100;
+            }
+        }
+
+        internal string BackgroundImgStyle => FormattableString.Invariant($"left:{_bacx}px;top:{_bacy}px;");
+
+        internal string RatioStyle => FormattableString.Invariant($"transform:scale({Ratio});");
+
+        internal string ImglistStyle => FormattableString.Invariant($"height:{CropperHeight}px;");
+
+        #endregion
+
+
+        #region vars
+
+        internal double _prevBacX = 0;
+        internal double _prevBacY = 0;
+        internal double _bacx = 0;
+        internal double _bacy = 0;
+        internal double _imgSize = 100;
+        internal bool _onTwoFingerResizing = false;
+        internal bool _isBacMoving = false;
+        internal double _prevTouchPointDistance = -1;
+        internal double _imgContainerWidth = 500;
+        internal double _imgContainerHeight = 150;
+        internal double _prevPosX = 0;
+        internal double _prevPosY = 0;
+        internal double _layoutX = 0;
+        internal double _layoutY = 0;
+        internal double _offsetX;
+        internal double _offsetY;
+        internal string _cropperStyle = "";
+        internal string _cropedImgStyle = "clip: rect(0, 150px, 150px, 0);";
+        internal bool _dragging = false;
+        internal bool _reSizing = false;
+        internal MoveDir _dir = MoveDir.UnKnown;
+        internal readonly double _minval = 30;
+        internal ImageData _image;
+        internal double _minposX;
+        internal double _minposY;
+        internal double _imgw;
+        internal double _imgh;
+        internal double _unsavedX;
+        internal double _unsavedY;
+        internal double _unsavedCropW;
+        internal double _unsavedCropH;
+        internal IBrowserFile _prevFile;
+        internal IImageFormat _format;
+        internal Image _gifimage;
+        internal double _ratio = 1d;
+        internal bool _evInitialized = false;
+        internal double _minvalx;
+        internal double _minvaly;
+
+        #endregion
+
+
+        #region static actions
+
+        internal static Action _setaction;
+        internal static Action<MouseEventArgs> _mouseMoveAction;
+        internal static Action<MouseEventArgs> _touchMoveAction;
+        internal static Action _touchEndAction;
+        internal static Action _mouseUpAction;
+
+        #endregion
+
+
+        #region Override methods
+
+        /// <inheritdoc />
+        protected override async Task OnInitializedAsync()
+        {
+            await JsRuntime.InvokeVoidAsync("setVersion", Environment.Version.Major);
+        }
+
+        /// <inheritdoc />
+        protected override void OnParametersSet()
+        {
+            base.OnParametersSet();
+            if (initCropWidth < 0)
+            {
+                initCropWidth = InitCropWidth;
+                initCropHeight = InitCropHeight;
+            }
+        }
+
+        /// <inheritdoc />
+        public async ValueTask DisposeAsync()
+        {
+            await JsRuntime.InvokeVoidAsync("rmCropperEventListeners");
+        }
+
+        private void InitAspectRatio()
+        {
+            _minvalx = _minval;
+            _minvaly = _minval;
+            if (!RequireAspectRatio)
+                return;
+
+            if (initCropHeight > initCropWidth * AspectRatio)
+            {
+                initCropWidth = initCropHeight / AspectRatio;
+                _minvalx = _minvaly / AspectRatio;
+            }
+            else
+            {
+                initCropHeight = initCropWidth * AspectRatio;
+                _minvaly = _minvalx * AspectRatio;
             }
 
-            // async function cropAsync(id, sx, sy, swidth, sheight, x, y, width, height, format)
-            string s = await JsRuntime.InvokeAsync<string>("cropAsync", "oriimg",
-                x, y, proportionalCropWidth, proportionalCropHeight, 0, 0,
-                proportionalCropWidth, proportionalCropHeight, _format.DefaultMimeType, Quality);
-            return new ImageCroppedResult(s, _format);
+            SetCropperStyle();
+            SetCroppedImgStyle();
         }
 
-        _gifimage.Mutate(ctx =>
+        /// <inheritdoc />
+        protected override async Task OnParametersSetAsync()
         {
-            // fix exif orientaion issue
-            ctx.AutoOrient();
-            ctx.Crop(rect);
-            if (resizeProp != 1d) ctx.Resize(new Size(proportionalCropWidth, proportionalCropHeight));
-        });
-        return new ImageCroppedResult(_gifimage, _format, Quality);
-    }
-
-    /// <summary>
-    ///     Returns the metadata about the cropper state.
-    /// </summary>
-    /// <returns></returns>
-    public CropInfo GetCropInfo()
-    {
-        double deltaX = 0;
-        double deltaY = 0;
-        (double resizeProp, double width, double height) = GetCropperInfos();
-        if (WiderThanContainer)
-            deltaY = -(_imgContainerHeight - _image.Height / resizeProp) / 2;
-        else
-            deltaX = -(_imgContainerWidth - _image.Width / resizeProp) / 2;
-        double x = _prevPosX - _bacx + deltaX;
-        double y = _prevPosY - _bacy + deltaY;
-
-
-        return new CropInfo
-        {
-            Rectangle = new Rectangle((int)(x * resizeProp), (int)(y * resizeProp),
-                (int)(width * resizeProp), (int)(height * resizeProp)),
-            Ratio = Ratio,
-            ResizeProp = resizeProp
-        };
-    }
-
-    #endregion
-
-
-    #region internal methods
-
-    internal string GetCropperStyle(double top, double left, double height, double width)
-        => FormattableString.Invariant($"top:{top}px;left:{left}px;height:{height}px;width:{width}px;");
-
-    internal string GetCroppedImgStyle(double top, double right, double bottom, double left)
-        => FormattableString.Invariant($"clip: rect({top}px, {right}px, {bottom}px, {left}px);");
-
-    internal (double resizeProp, double cw, double ch) GetCropperInfos()
-    {
-        double resizeProp = 1d;
-        double cw = initCropWidth;
-        double ch = initCropHeight;
-        if (WiderThanContainer)
-            resizeProp = _image.Width / _imgContainerWidth;
-        else
-            resizeProp = _image.Height / _imgContainerHeight;
-        return (resizeProp, cw, ch);
-    }
-
-
-    internal void SetCroppedImgStyle()
-    {
-        _cropedImgStyle = GetCroppedImgStyle(_prevPosY - _layoutY, _prevPosX - _layoutX + initCropWidth, _prevPosY - _layoutY + initCropHeight,
-            _prevPosX - _layoutX);
-    }
-
-    internal void SetCropperStyle()
-    {
-        _cropperStyle = GetCropperStyle(_prevPosY, _prevPosX, initCropHeight, initCropWidth);
-    }
-
-    internal void TouchToMouse(TouchEventArgs args, Action<MouseEventArgs> handler)
-    {
-        if (args != null && args.Touches != null && args.Touches.Length > 0) //TODO args.Touches != null is never null
-            handler(new MouseEventArgs
-            {
-                ClientX = args.Touches[0].ClientX,
-                ClientY = args.Touches[0].ClientY
-            });
-    }
-
-    internal void OnDragStart(MouseEventArgs args)
-    {
-        if (_reSizing) return;
-        SetCropperStyle();
-        _offsetX = args.ClientX;
-        _offsetY = args.ClientY;
-        _dragging = true;
-    }
-
-    internal void OnDragging(MouseEventArgs args)
-    {
-        if (!_dragging || _reSizing)
-            return;
-
-        double x = _prevPosX - (_offsetX - args.ClientX) / Ratio;
-        double y = _prevPosY - (_offsetY - args.ClientY) / Ratio;
-        if (y < _minposY) y = _minposY;
-        if (x < _minposX) x = _minposX;
-        if (y + initCropHeight > _minposY + _imgh) y = _minposY + _imgh - initCropHeight;
-        if (x + initCropWidth > _minposX + _imgw) x = _minposX + _imgw - initCropWidth;
-        _unsavedX = x;
-        _unsavedY = y;
-
-        _cropperStyle = GetCropperStyle(y, x, initCropHeight, initCropWidth);
-        _cropedImgStyle = GetCroppedImgStyle(y - _layoutY, x - _layoutX + initCropWidth, y - _layoutY + initCropHeight, x - _layoutX);
-        StateHasChanged();
-    }
-
-    internal void OnDragEnd()
-    {
-        _dragging = false;
-        _prevPosX = _unsavedX;
-        _prevPosY = _unsavedY;
-    }
-
-    internal void OnResizeStart(MouseEventArgs args, MoveDir dir)
-    {
-        _dir = dir;
-        if (_dragging)
-            return;
-
-        SetCropperStyle();
-        _offsetX = args.ClientX;
-        _offsetY = args.ClientY;
-        if (IsCropLocked && !_isBacMoving && !_onTwoFingerResizing)
-        {
-            OnDragStart(args);
-            return;
+            await base.OnParametersSetAsync();
+            InitAspectRatio();
+            if (_prevFile == ImageFile)
+                return;
+            _prevFile = ImageFile;
+            string ext = ImageFile.Name.Split('.').Last().ToLower();
+            IBrowserFile resizedImageFile = ImageFile;
+            await Task.Delay(10);
+            _gifimage?.Dispose();
+            await LoadImage(ext, resizedImageFile);
+            await InitJSAsync();
+            await SetImgContainterSize();
+            await OnLoad.InvokeAsync();
+            await SizeChanged();
         }
 
-        _reSizing = true;
-    }
-
-    internal async ValueTask LoadImage(string ext, IBrowserFile resizedImageFile)
-    {
-        if (PureCSharpProcessing || string.IsNullOrEmpty(InputId) || (ext == "gif" && AnimeGifEnable))
+        private async Task InitJSAsync()
         {
-            byte[] buffer = new byte[resizedImageFile.Size];
-            if (Environment.Version.Major == 6)
+            double[] data = { 0, 0 };
+            while (data[0] == 0d)
             {
-                bool isClientSide = JsRuntime is IJSInProcessRuntime;
-                if (isClientSide)
+                await Task.Delay(10);
+                data = await JsRuntime.InvokeAsync<double[]>("getOriImgSize");
+            }
+
+            _image = new ImageData
+            {
+                Width = data[0],
+                Height = data[1]
+            };
+            if (!_evInitialized)
+            {
+                await JsRuntime.InvokeVoidAsync("addCropperEventListeners");
+                _evInitialized = true;
+            }
+        }
+
+        /// <inheritdoc />
+        protected override async Task OnAfterRenderAsync(bool first)
+        {
+            await base.OnAfterRenderAsync(first);
+            if (first)
+            {
+                _setaction = () => SetImgContainterSize();
+                _mouseMoveAction = args =>
                 {
-                    await resizedImageFile.OpenReadStream(1024 * 1024 * 90).ReadAsync(buffer);
+                    OnSizeChanging(args);
+                    OnResizeBackGroundImage(MouseToTouch(args));
+                };
+                _mouseUpAction = () =>
+                {
+                    if (_onTwoFingerResizing || _isBacMoving)
+                    {
+                        _isBacMoving = false;
+                        _onTwoFingerResizing = false;
+                        InitBox();
+                    }
+
+                    OnSizeChangeEnd();
+                };
+                _touchMoveAction = OnSizeChanging;
+                _touchEndAction = () => { OnSizeChangeEnd(); };
+            }
+        }
+
+        #endregion
+
+        #region JsInvokable methods
+
+        [JSInvokable("OnTouchEnd")]
+        public static void TouchEndCaller()
+        {
+            _touchEndAction?.Invoke();
+        }
+
+        [JSInvokable("OnTouchMove")]
+        public static void TouchMoveCaller(MouseEventArgs args)
+        {
+            _touchMoveAction?.Invoke(args);
+        }
+
+        [JSInvokable("OnMouseUp")]
+        public static void MouseUpCaller()
+        {
+            _mouseUpAction?.Invoke();
+        }
+
+        [JSInvokable("OnMouseMove")]
+        public static void MouseMoveCaller(MouseEventArgs args)
+        {
+            _mouseMoveAction?.Invoke(args);
+        }
+
+        [JSInvokable("SetWidthHeight")]
+        public static void SetWidthHeightCaller()
+        {
+            _setaction?.Invoke();
+        }
+
+        #endregion
+
+
+        #region Public methods
+
+        /// <summary>
+        ///     Get the crop result.
+        /// </summary>
+        /// <returns>crop result</returns>
+        public async Task<ImageCroppedResult> GetCropedResult()
+        {
+            CropInfo info = GetCropInfo();
+            Rectangle rect = info.Rectangle;
+            (int x, int y, int proportionalCropWidth, int proportionalCropHeight, double resizeProp) =
+                (rect.X, rect.Y, rect.Width, rect.Height, info.ResizeProp);
+
+            double finalImageHeight = FinalCropHeight != 0 ? FinalCropHeight : proportionalCropHeight;
+            double finalImageWidth = FinalCropWidth != 0 ? FinalCropWidth : proportionalCropWidth;
+
+            if (_gifimage == null)
+            {
+                if (Environment.Version.Major > 5)
+                {
+                    // for dotnet version after 5, pass byte array between c# and js is optimized
+                    // async function cropAsync(id, sx, sy, swidth, sheight, x, y, width, height, format)
+                    byte[] bin = await JsRuntime.InvokeAsync<byte[]>("cropAsync", "oriimg",
+                        x, y, proportionalCropWidth, proportionalCropHeight, 0, 0,
+                        finalImageWidth, finalImageHeight, _format.DefaultMimeType, Quality);
+                    return new ImageCroppedResult(bin, _format);
+                }
+
+                // async function cropAsync(id, sx, sy, swidth, sheight, x, y, width, height, format)
+                string s = await JsRuntime.InvokeAsync<string>("cropAsync", "oriimg",
+                    x, y, proportionalCropWidth, proportionalCropHeight, 0, 0,
+                    finalImageWidth, finalImageHeight, _format.DefaultMimeType, Quality);
+                return new ImageCroppedResult(s, _format);
+            }
+
+            _gifimage.Mutate(ctx =>
+            {
+                // fix exif orientaion issue
+                ctx.AutoOrient();
+                ctx.Crop(rect);
+                if (resizeProp != 1d) ctx.Resize(new Size(proportionalCropWidth, proportionalCropHeight));
+            });
+            return new ImageCroppedResult(_gifimage, _format, Quality);
+        }
+
+        /// <summary>
+        ///     Returns the metadata about the cropper state.
+        /// </summary>
+        /// <returns></returns>
+        public CropInfo GetCropInfo()
+        {
+            double deltaX = 0;
+            double deltaY = 0;
+            (double resizeProp, double width, double height) = GetCropperInfos();
+            if (WiderThanContainer)
+                deltaY = -(_imgContainerHeight - _image.Height / resizeProp) / 2;
+            else
+                deltaX = -(_imgContainerWidth - _image.Width / resizeProp) / 2;
+            double x = _prevPosX - _bacx + deltaX;
+            double y = _prevPosY - _bacy + deltaY;
+
+
+            return new CropInfo
+            {
+                Rectangle = new Rectangle((int)(x * resizeProp), (int)(y * resizeProp),
+                    (int)(width * resizeProp), (int)(height * resizeProp)),
+                Ratio = Ratio,
+                ResizeProp = resizeProp
+            };
+        }
+
+        #endregion
+
+
+        #region internal methods
+
+        internal string GetCropperStyle(double top, double left, double height, double width)
+            => FormattableString.Invariant($"top:{top}px;left:{left}px;height:{height}px;width:{width}px;");
+
+        internal string GetCroppedImgStyle(double top, double right, double bottom, double left)
+            => FormattableString.Invariant($"clip: rect({top}px, {right}px, {bottom}px, {left}px);");
+
+        internal (double resizeProp, double cw, double ch) GetCropperInfos()
+        {
+            double resizeProp = 1d;
+            double cw = initCropWidth;
+            double ch = initCropHeight;
+            if (WiderThanContainer)
+                resizeProp = _image.Width / _imgContainerWidth;
+            else
+                resizeProp = _image.Height / _imgContainerHeight;
+            return (resizeProp, cw, ch);
+        }
+
+
+        internal void SetCroppedImgStyle()
+        {
+            _cropedImgStyle = GetCroppedImgStyle(_prevPosY - _layoutY, _prevPosX - _layoutX + initCropWidth, _prevPosY - _layoutY + initCropHeight,
+                _prevPosX - _layoutX);
+        }
+
+        internal void SetCropperStyle()
+        {
+            _cropperStyle = GetCropperStyle(_prevPosY, _prevPosX, initCropHeight, initCropWidth);
+        }
+
+        internal void TouchToMouse(TouchEventArgs args, Action<MouseEventArgs> handler)
+        {
+            if (args != null && args.Touches != null && args.Touches.Length > 0) //TODO args.Touches != null is never null
+                handler(new MouseEventArgs
+                {
+                    ClientX = args.Touches[0].ClientX,
+                    ClientY = args.Touches[0].ClientY
+                });
+        }
+
+        internal void OnDragStart(MouseEventArgs args)
+        {
+            if (_reSizing) return;
+            SetCropperStyle();
+            _offsetX = args.ClientX;
+            _offsetY = args.ClientY;
+            _dragging = true;
+        }
+
+        internal void OnDragging(MouseEventArgs args)
+        {
+            if (!_dragging || _reSizing)
+                return;
+
+            double x = _prevPosX - (_offsetX - args.ClientX) / Ratio;
+            double y = _prevPosY - (_offsetY - args.ClientY) / Ratio;
+            if (y < _minposY) y = _minposY;
+            if (x < _minposX) x = _minposX;
+            if (y + initCropHeight > _minposY + _imgh) y = _minposY + _imgh - initCropHeight;
+            if (x + initCropWidth > _minposX + _imgw) x = _minposX + _imgw - initCropWidth;
+            _unsavedX = x;
+            _unsavedY = y;
+
+            _cropperStyle = GetCropperStyle(y, x, initCropHeight, initCropWidth);
+            _cropedImgStyle = GetCroppedImgStyle(y - _layoutY, x - _layoutX + initCropWidth, y - _layoutY + initCropHeight, x - _layoutX);
+            StateHasChanged();
+        }
+
+        internal void OnDragEnd()
+        {
+            _dragging = false;
+            _prevPosX = _unsavedX;
+            _prevPosY = _unsavedY;
+        }
+
+        internal void OnResizeStart(MouseEventArgs args, MoveDir dir)
+        {
+            _dir = dir;
+            if (_dragging)
+                return;
+
+            SetCropperStyle();
+            _offsetX = args.ClientX;
+            _offsetY = args.ClientY;
+            if (IsCropLocked && !_isBacMoving && !_onTwoFingerResizing)
+            {
+                OnDragStart(args);
+                return;
+            }
+
+            _reSizing = true;
+        }
+
+        internal async ValueTask LoadImage(string ext, IBrowserFile resizedImageFile)
+        {
+            if (PureCSharpProcessing || string.IsNullOrEmpty(InputId) || (ext == "gif" && AnimeGifEnable))
+            {
+                byte[] buffer = new byte[resizedImageFile.Size];
+                if (Environment.Version.Major == 6)
+                {
+                    bool isClientSide = JsRuntime is IJSInProcessRuntime;
+                    if (isClientSide)
+                    {
+                        await resizedImageFile.OpenReadStream(1024 * 1024 * 90).ReadAsync(buffer);
+                    }
+                    else
+                    {
+                        // WORKAROUND https://github.com/Chronostasys/Blazor.Cropper/issues/43
+                        StreamContent fileContent = new(resizedImageFile.OpenReadStream(1024 * 1024 * 90));
+                        buffer = await fileContent.ReadAsByteArrayAsync();
+                    }
                 }
                 else
                 {
-                    // WORKAROUND https://github.com/Chronostasys/Blazor.Cropper/issues/43
-                    StreamContent fileContent = new(resizedImageFile.OpenReadStream(1024 * 1024 * 90));
-                    buffer = await fileContent.ReadAsByteArrayAsync();
+                    await resizedImageFile.OpenReadStream(1024 * 1024 * 90).ReadAsync(buffer);
                 }
-            }
-            else
-            {
-                await resizedImageFile.OpenReadStream(1024 * 1024 * 90).ReadAsync(buffer);
-            }
 
-            if ((ext == "gif" && AnimeGifEnable) || PureCSharpProcessing)
-            {
-                _gifimage = Image.Load(buffer, out _format);
-                await JsRuntime.InvokeVoidAsync("setImgSrc", buffer, _format.DefaultMimeType);
-            }
-            else
-            {
-                ImageFormatManager m = Configuration.Default.ImageFormatsManager;
-
-                _format = m.FindFormatByFileExtension(ext) ?? PngFormat.Instance;
-                await JsRuntime.InvokeVoidAsync("setImgSrc", buffer, "image/" + ext);
-            }
-        }
-        else
-        {
-            await JsRuntime.InvokeVoidAsync("setImg", InputId);
-        }
-    }
-
-    internal void OnSizeChanging(MouseEventArgs args)
-    {
-        if (_reSizing && !_dragging)
-        {
-            double deltaY = (args.ClientY - _offsetY) / Ratio;
-            double deltaX = (args.ClientX - _offsetX) / Ratio;
-            CropBox cb = new(this);
-            cb.DragCorner(deltaX, deltaY, _dir);
-            _unsavedX = cb.X;
-            _unsavedY = cb.Y;
-            _unsavedCropH = cb.H;
-            _unsavedCropW = cb.W;
-            _cropperStyle = GetCropperStyle(cb.Y, cb.X, cb.H, cb.W);
-            _cropedImgStyle = GetCroppedImgStyle(cb.Y - _layoutY, cb.X - _layoutX + cb.W, cb.Y - _layoutY + cb.H, cb.X - _layoutX);
-        }
-
-        OnDragging(args);
-        StateHasChanged();
-    }
-
-    internal void OnSizeChangeEnd()
-    {
-        if (_reSizing)
-        {
-            _reSizing = false;
-            initCropHeight = _unsavedCropH;
-            initCropWidth = _unsavedCropW;
-            _prevPosY = _unsavedY;
-            _prevPosX = _unsavedX;
-            SizeChanged();
-            return;
-        }
-
-        if (_dragging) OnDragEnd();
-        SizeChanged();
-    }
-
-    internal Task SizeChanged()
-    {
-        (double resizeProp, double cw, double ch) = GetCropperInfos();
-        return OnSizeChanged.InvokeAsync((cw * resizeProp, ch * resizeProp));
-    }
-
-    internal TouchEventArgs MouseToTouch(MouseEventArgs args)
-    {
-        return new TouchEventArgs
-        {
-            Touches = new[]
-            {
-                new TouchPoint
+                if ((ext == "gif" && AnimeGifEnable) || PureCSharpProcessing)
                 {
-                    ClientX = args.ClientX,
-                    ClientY = args.ClientY
+                    _gifimage = Image.Load(buffer, out _format);
+                    await JsRuntime.InvokeVoidAsync("setImgSrc", buffer, _format.DefaultMimeType);
+                }
+                else
+                {
+                    ImageFormatManager m = Configuration.Default.ImageFormatsManager;
+
+                    _format = m.FindFormatByFileExtension(ext) ?? PngFormat.Instance;
+                    await JsRuntime.InvokeVoidAsync("setImgSrc", buffer, "image/" + ext);
                 }
             }
-        };
-    }
+            else
+            {
+                await JsRuntime.InvokeVoidAsync("setImg", InputId);
+            }
+        }
 
-    internal void GuardImgPosition()
-    {
-        if (WiderThanContainer)
+        internal void OnSizeChanging(MouseEventArgs args)
         {
-            _minposX = 0;
-            _minposY = (_imgContainerHeight - ImgRealH) / 2;
-        }
-        else
-        {
-            _minposY = 0;
-            _minposX = (_imgContainerWidth - ImgRealW) / 2;
-        }
-    }
+            if (_reSizing && !_dragging)
+            {
+                double deltaY = (args.ClientY - _offsetY) / Ratio;
+                double deltaX = (args.ClientX - _offsetX) / Ratio;
+                CropBox cb = new(this);
+                cb.DragCorner(deltaX, deltaY, _dir);
+                _unsavedX = cb.X;
+                _unsavedY = cb.Y;
+                _unsavedCropH = cb.H;
+                _unsavedCropW = cb.W;
+                _cropperStyle = GetCropperStyle(cb.Y, cb.X, cb.H, cb.W);
+                _cropedImgStyle = GetCroppedImgStyle(cb.Y - _layoutY, cb.X - _layoutX + cb.W, cb.Y - _layoutY + cb.H, cb.X - _layoutX);
+            }
 
-    internal void ResizeBac(double i)
-    {
-        double temp = _imgSize;
-        if ((_imgSize * i < 100 && i < 1) ||
-            (ImgRealW * i > _imgContainerWidth && ImgRealH * i > _imgContainerHeight && i > 1))
-            return;
-        _imgSize *= i;
-        GuardImgPosition();
-        _minposY += _bacy - (_imgSize - temp) / _imgSize * ImgRealH / 2;
-        _minposX += _bacx;
-        if (_prevPosX + initCropWidth > _minposX + ImgRealW || _prevPosX < _minposX
-                                                            || _prevPosY + initCropHeight > _minposY + ImgRealH || _prevPosY < _minposY)
-        {
-            _imgSize /= i;
+            OnDragging(args);
+            StateHasChanged();
         }
-        else
-        {
-            _bacy -= (i - 1) * ImgRealH / 2;
-            _layoutY -= (i - 1) * ImgRealH / 2;
-            SetCroppedImgStyle();
-        }
-    }
 
-    internal void OnResizeBackGroundImage(TouchEventArgs args)
-    {
-        if (args.Touches.Length == 1)
+        internal void OnSizeChangeEnd()
         {
-            if (!_isBacMoving) return;
-            double dx = (args.Touches[0].ClientX - _prevBacX) / Ratio;
-            double dy = (args.Touches[0].ClientY - _prevBacY) / Ratio;
+            if (_reSizing)
+            {
+                _reSizing = false;
+                initCropHeight = _unsavedCropH;
+                initCropWidth = _unsavedCropW;
+                _prevPosY = _unsavedY;
+                _prevPosX = _unsavedX;
+                SizeChanged();
+                return;
+            }
+
+            if (_dragging) OnDragEnd();
+            SizeChanged();
+        }
+
+        internal Task SizeChanged()
+        {
+            (double resizeProp, double cw, double ch) = GetCropperInfos();
+            return OnSizeChanged.InvokeAsync((cw * resizeProp, ch * resizeProp));
+        }
+
+        internal TouchEventArgs MouseToTouch(MouseEventArgs args)
+        {
+            return new TouchEventArgs
+            {
+                Touches = new[]
+                {
+                    new TouchPoint
+                    {
+                        ClientX = args.ClientX,
+                        ClientY = args.ClientY
+                    }
+                }
+            };
+        }
+
+        internal void GuardImgPosition()
+        {
+            if (WiderThanContainer)
+            {
+                _minposX = 0;
+                _minposY = (_imgContainerHeight - ImgRealH) / 2;
+            }
+            else
+            {
+                _minposY = 0;
+                _minposX = (_imgContainerWidth - ImgRealW) / 2;
+            }
+        }
+
+        internal void ResizeBac(double i)
+        {
+            double temp = _imgSize;
+            if ((_imgSize * i < 100 && i < 1) ||
+                (ImgRealW * i > _imgContainerWidth && ImgRealH * i > _imgContainerHeight && i > 1))
+                return;
+            _imgSize *= i;
             GuardImgPosition();
-            _minposY += _bacy + dy;
-            _minposX += _bacx + dx;
-            _bacx += dx;
-            _bacy += dy;
-            _layoutX += dx;
-            _layoutY += dy;
-            if (_prevPosX + initCropWidth > _minposX + ImgRealW || _prevPosX < _minposX)
+            _minposY += _bacy - (_imgSize - temp) / _imgSize * ImgRealH / 2;
+            _minposX += _bacx;
+            if (_prevPosX + initCropWidth > _minposX + ImgRealW || _prevPosX < _minposX
+                                                                || _prevPosY + initCropHeight > _minposY + ImgRealH || _prevPosY < _minposY)
             {
-                _bacx -= dx;
-                _layoutX -= dx;
-                _minposX -= _bacx;
+                _imgSize /= i;
+            }
+            else
+            {
+                _bacy -= (i - 1) * ImgRealH / 2;
+                _layoutY -= (i - 1) * ImgRealH / 2;
+                SetCroppedImgStyle();
+            }
+        }
+
+        internal void OnResizeBackGroundImage(TouchEventArgs args)
+        {
+            if (args.Touches.Length == 1)
+            {
+                if (!_isBacMoving) return;
+                double dx = (args.Touches[0].ClientX - _prevBacX) / Ratio;
+                double dy = (args.Touches[0].ClientY - _prevBacY) / Ratio;
+                GuardImgPosition();
+                _minposY += _bacy + dy;
+                _minposX += _bacx + dx;
+                _bacx += dx;
+                _bacy += dy;
+                _layoutX += dx;
+                _layoutY += dy;
+                if (_prevPosX + initCropWidth > _minposX + ImgRealW || _prevPosX < _minposX)
+                {
+                    _bacx -= dx;
+                    _layoutX -= dx;
+                    _minposX -= _bacx;
+                }
+
+                if (_prevPosY + initCropHeight > _minposY + ImgRealH || _prevPosY < _minposY)
+                {
+                    _bacy -= dy;
+                    _layoutY -= dy;
+                    _minposY -= _bacy;
+                }
+
+                SetCroppedImgStyle();
+                _prevBacX = args.Touches[0].ClientX;
+                _prevBacY = args.Touches[0].ClientY;
             }
 
-            if (_prevPosY + initCropHeight > _minposY + ImgRealH || _prevPosY < _minposY)
+            if (args.Touches.Length != 2 || IsImageLocked) return;
+            // two finger resize
+            double distance = Math.Pow(args.Touches[0].ClientX - args.Touches[1].ClientX, 2) +
+                              Math.Pow(args.Touches[0].ClientY - args.Touches[1].ClientY, 2);
+            if (_onTwoFingerResizing)
             {
-                _bacy -= dy;
-                _layoutY -= dy;
-                _minposY -= _bacy;
+                double i = distance / _prevTouchPointDistance;
+                ResizeBac(i);
+                Ratio = _imgSize / 100;
+            }
+            else
+            {
+                _onTwoFingerResizing = true;
             }
 
+            _prevTouchPointDistance = distance;
+        }
+
+        internal async Task SetImgContainterSize()
+        {
+            double[] t = await JsRuntime.InvokeAsync<double[]>("getWidthHeight");
+            // in the case that container has not yet loaded 
+            while (t[0] == 0)
+            {
+                await Task.Delay(10);
+                t = await JsRuntime.InvokeAsync<double[]>("getWidthHeight");
+            }
+
+            _imgContainerWidth = t[0];
+            _imgContainerHeight = t[1];
+            InitStyles();
+        }
+
+        internal void InitBox()
+        {
+            double prevPosX = 0d, prevPosY = 0d;
+
+            InitPos(ref prevPosX, ref prevPosY);
+        }
+
+        internal void InitPos(ref double prevPosX, ref double prevPosY)
+        {
+            if (WiderThanContainer)
+            {
+                prevPosY = (_imgContainerHeight - ImgRealH) / 2;
+                prevPosX = 0;
+            }
+            else
+            {
+                prevPosX = Math.Abs(_imgContainerWidth - ImgRealW) / 2;
+                prevPosY = 0;
+            }
+
+            prevPosY += _bacy;
+            prevPosX += _bacx;
+            _minposX = prevPosX;
+            _minposY = prevPosY;
+            _imgw = ImgRealW;
+            _imgh = ImgRealH;
+        }
+
+        internal void InitStyles()
+        {
+            InitPos(ref _prevPosX, ref _prevPosY);
+            _prevPosX += OffsetX;
+            _prevPosY += OffsetY;
+
+            if (initCropHeight > _imgh) initCropHeight = _imgh;
+            if (initCropWidth > _imgw) initCropWidth = _imgw;
+
+            SetCropperStyle();
             SetCroppedImgStyle();
-            _prevBacX = args.Touches[0].ClientX;
-            _prevBacY = args.Touches[0].ClientY;
+            StateHasChanged();
         }
 
-        if (args.Touches.Length != 2 || IsImageLocked) return;
-        // two finger resize
-        double distance = Math.Pow(args.Touches[0].ClientX - args.Touches[1].ClientX, 2) +
-                          Math.Pow(args.Touches[0].ClientY - args.Touches[1].ClientY, 2);
-        if (_onTwoFingerResizing)
-        {
-            double i = distance / _prevTouchPointDistance;
-            ResizeBac(i);
-            Ratio = _imgSize / 100;
-        }
-        else
-        {
-            _onTwoFingerResizing = true;
-        }
-
-        _prevTouchPointDistance = distance;
+        #endregion
     }
-
-    internal async Task SetImgContainterSize()
-    {
-        double[] t = await JsRuntime.InvokeAsync<double[]>("getWidthHeight");
-        // in the case that container has not yet loaded 
-        while (t[0] == 0)
-        {
-            await Task.Delay(10);
-            t = await JsRuntime.InvokeAsync<double[]>("getWidthHeight");
-        }
-
-        _imgContainerWidth = t[0];
-        _imgContainerHeight = t[1];
-        InitStyles();
-    }
-
-    internal void InitBox()
-    {
-        double prevPosX = 0d, prevPosY = 0d;
-
-        InitPos(ref prevPosX, ref prevPosY);
-    }
-
-    internal void InitPos(ref double prevPosX, ref double prevPosY)
-    {
-        if (WiderThanContainer)
-        {
-            prevPosY = (_imgContainerHeight - ImgRealH) / 2;
-            prevPosX = 0;
-        }
-        else
-        {
-            prevPosX = Math.Abs(_imgContainerWidth - ImgRealW) / 2;
-            prevPosY = 0;
-        }
-
-        prevPosY += _bacy;
-        prevPosX += _bacx;
-        _minposX = prevPosX;
-        _minposY = prevPosY;
-        _imgw = ImgRealW;
-        _imgh = ImgRealH;
-    }
-
-    internal void InitStyles()
-    {
-        InitPos(ref _prevPosX, ref _prevPosY);
-        _prevPosX += OffsetX;
-        _prevPosY += OffsetY;
-
-        if (initCropHeight > _imgh) initCropHeight = _imgh;
-        if (initCropWidth > _imgw) initCropWidth = _imgw;
-
-        SetCropperStyle();
-        SetCroppedImgStyle();
-        StateHasChanged();
-    }
-
-    #endregion
 }

--- a/Blazor.Cropper/Cropper.razor.cs
+++ b/Blazor.Cropper/Cropper.razor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -9,894 +8,869 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.JSInterop;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Processing;
 
-namespace Blazor.Cropper
+namespace Blazor.Cropper;
+
+/// <summary>
+///     Cropper component
+/// </summary>
+public partial class Cropper : IAsyncDisposable
 {
+    [Inject] internal IJSRuntime JsRuntime { get; set; }
+
+    #region params
+
     /// <summary>
-    /// Cropper component
+    ///     whether use c# for ordinary img processing
     /// </summary>
-    public partial class Cropper : IAsyncDisposable
+    /// <value>default: false</value>
+    [Parameter]
+    public bool PureCSharpProcessing { get; set; } = false;
+
+    /// <summary>
+    ///     If this property is true, the image will become
+    ///     unresizable in cropper
+    /// </summary>
+    /// <value>default: true</value>
+    [Parameter]
+    public bool IsImageLocked { get; set; } = true;
+
+    /// <summary>
+    ///     the initial width of cropper if possible.
+    ///     shall not be smaller than 30.
+    /// </summary>
+    /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
+    /// <value>default: 150</value>
+    [Parameter]
+    public double InitCropWidth { get; set; } = 150;
+
+    internal double initCropWidth = -1;
+
+    /// <summary>
+    ///     the initial height of cropper if possible.
+    ///     shall not be smaller than 30.
+    /// </summary>
+    /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
+    /// <value>default: 150</value>
+    [Parameter]
+    public double InitCropHeight { get; set; } = 150;
+
+    internal double initCropHeight = -1;
+
+    /// <summary>
+    ///     sepecify whether the cropper's aspect ratio is fixed
+    /// </summary>
+    /// <value>default: false</value>
+    [Parameter]
+    public bool RequireAspectRatio { get; set; } = false;
+
+    /// <summary>
+    ///     sepecify the cropper's aspect ratio
+    /// </summary>
+    /// <remarks>
+    ///     Only works when <see cref="RequireAspectRatio" />
+    ///     is true
+    /// </remarks>
+    /// <value>default: 1</value>
+    [Parameter]
+    public double AspectRatio { get; set; } = 1;
+
+    /// <summary>
+    ///     The input image file. Usually get from an
+    ///     <see cref="InputFile" /> Component. You can also
+    ///     mock a file from stream using <see cref="StreamFile" /> if needed.
+    /// </summary>
+    /// <value></value>
+    [Parameter]
+    public IBrowserFile ImageFile { get; set; }
+
+    /// <summary>
+    ///     Fire when the image file load into cropper
+    /// </summary>
+    /// <value></value>
+    [Parameter]
+    public EventCallback OnLoad { get; set; }
+
+    /// <summary>
+    ///     Set whether the anime gif crop is enabled. If enabled,
+    ///     the gif file smaller than 1mb would
+    ///     be cropped as animed image. If disabled, only the first
+    ///     frame would be cropped.
+    /// </summary>
+    /// <remarks>
+    ///     Crop large gif image can cause the window stop responding
+    ///     for half a minute!
+    /// </remarks>
+    /// <value>default: true</value>
+    [Parameter]
+    public bool AnimeGifEnable { get; set; } = true;
+
+    /// <summary>
+    ///     The input element's id value. This param is optional and
+    ///     can help cropper to init image
+    ///     faster on browser before dotnet core version 6.
+    ///     Does't have effect if <see cref="PureCSharpProcessing" /> is true.
+    /// </summary>
+    [Parameter]
+    public string InputId { get; set; }
+
+    /// <summary>
+    ///     Max allowed crop result height. Should not be larger than 500.
+    /// </summary>
+    /// <value>default:500</value>
+    [Parameter]
+    public double MaxCropedHeight { get; set; } = 500;
+
+    /// <summary>
+    ///     Max allowed crop result width. Should not be larger than 500.
+    /// </summary>
+    /// <value>default:500</value>
+    [Parameter]
+    public double MaxCropedWidth { get; set; } = 500;
+
+    /// <summary>
+    ///     Height of this component in px
+    /// </summary>
+    /// <value>default:150</value>
+    [Parameter]
+    public double CropperHeight { get; set; } = 150;
+
+    /// <summary>
+    ///     Whether the cropper size is locked
+    /// </summary>
+    /// <value>default: false</value>
+    [Parameter]
+    public bool IsCropLocked { get; set; } = false;
+
+    /// <summary>
+    ///     The scaling ratio, should be bind two way.
+    /// </summary>
+    /// <value>default: 1.0</value>
+    [Parameter]
+    public double Ratio
     {
-        [Inject]
-        internal IJSRuntime JSRuntime { get; set; }
-
-        #region params
-
-        /// <summary>
-        /// whether use c# for ordinary img processing
-        /// </summary>
-        /// <value>default: false</value>
-        [Parameter]
-        public bool PureCSharpProcessing { get; set; } = false;
-        /// <summary>
-        /// If this property is true, the image will become
-        /// unresizable in cropper
-        /// </summary>
-        /// <value>default: true</value>
-        [Parameter]
-        public bool IsImageLocked { get; set; } = true;
-        /// <summary>
-        /// the initial width of cropper if possible.
-        /// shall not be smaller than 30.
-        /// </summary>
-        /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams"/></remarks>
-        /// <value>default: 150</value>
-        [Parameter]
-        public double InitCropWidth { get; set; } = 150;
-
-        internal double initCropWidth = -1;
-        /// <summary>
-        /// the initial height of cropper if possible.
-        /// shall not be smaller than 30.
-        /// </summary>
-        /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams"/></remarks>
-        /// <value>default: 150</value>
-        [Parameter]
-        public double InitCropHeight { get; set; } = 150;
-
-        internal double initCropHeight = -1;
-        /// <summary>
-        /// sepecify whether the cropper's aspect ratio is fixed
-        /// </summary>
-        /// <value>default: false</value>
-        [Parameter]
-        public bool RequireAspectRatio { get; set; } = false;
-        /// <summary>
-        /// sepecify the cropper's aspect ratio
-        /// </summary>
-        /// <remarks>Only works when <see cref="RequireAspectRatio"/>
-        /// is true</remarks>
-        /// <value>default: 1</value>
-        [Parameter]
-        public double AspectRatio { get; set; } = 1;
-        /// <summary>
-        /// The input image file. Usually get from an
-        /// <see cref="InputFile"/> Component. You can also
-        /// mock a file from stream using <see cref="StreamFile"/> if needed.
-        /// </summary>
-        /// <value></value>
-        [Parameter]
-        public IBrowserFile ImageFile { get; set; }
-        /// <summary>
-        /// Fire when the image file load into cropper
-        /// </summary>
-        /// <value></value>
-        [Parameter]
-        public EventCallback OnLoad { get; set; }
-        /// <summary>
-        /// Set whether the anime gif crop is enabled. If enabled,
-        /// the gif file smaller than 1mb would 
-        /// be cropped as animed image. If disabled, only the first
-        /// frame would be cropped.
-        /// </summary>
-        /// <remarks>Crop large gif image can cause the window stop responding
-        /// for half a minute!</remarks>
-        /// <value>default: true</value>
-        [Parameter]
-        public bool AnimeGifEnable { get; set; } = true;
-        /// <summary>
-        /// The input element's id value. This param is optional and
-        /// can help cropper to init image
-        /// faster on browser before dotnet core version 6.
-        /// Does't have effect if <see cref="PureCSharpProcessing"/> is true.
-        /// </summary>
-        [Parameter]
-        public string InputId { get; set; }
-        /// <summary>
-        /// Max allowed crop result height. Should not be larger than 500.
-        /// </summary>
-        /// <value>default:500</value>
-        [Parameter]
-        public double MaxCropedHeight { get; set; } = 500;
-        /// <summary>
-        /// Max allowed crop result width. Should not be larger than 500.
-        /// </summary>
-        /// <value>default:500</value>
-        [Parameter]
-        public double MaxCropedWidth { get; set; } = 500;
-        /// <summary>
-        /// Height of this component in px
-        /// </summary>
-        /// <value>default:150</value>
-        [Parameter]
-        public double CropperHeight { get; set; } = 150;
-        /// <summary>
-        /// Whether the cropper size is locked
-        /// </summary>
-        /// <value>default: false</value>
-        [Parameter]
-        public bool IsCropLocked { get; set; } = false;
-        /// <summary>
-        /// The scaling ratio, should be bind two way.
-        /// </summary>
-        /// <value>default: 1.0</value>
-        [Parameter]
-        public double Ratio
+        get => _ratio;
+        set
         {
-            get => _ratio;
-            set
-            {
-                if (value == _ratio || IsImageLocked)
-                {
-                    return;
-                }
+            if (value == _ratio || IsImageLocked) return;
 
-                _ratio = value;
-                RatioChanged.InvokeAsync(value);
-            }
+            _ratio = value;
+            RatioChanged.InvokeAsync(value);
         }
-        /// <summary>
-        /// Fire when scaling ratio changed by touch event.
-        /// </summary>
-        [Parameter]
-        public EventCallback<double> RatioChanged { get; set; }
-        /// <summary>
-        /// Fire when cropper size changed. 
-        /// Item1 of the return tuple is width, Item2 is height
-        /// </summary>
-        [Parameter]
-        public EventCallback<(double, double)> OnSizeChanged { get; set; }
-        /// <summary>
-        /// Used to set the cropper initial offset position.
-        /// </summary>
-        /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams"/></remarks>
-        [Parameter]
-        public double OffsetX { set; get; }
-        /// <summary>
-        /// Used to set the cropper initial offset position.
-        /// </summary>
-        /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams"/></remarks>
-        [Parameter]
-        public double OffsetY { set; get; }
-        /// <summary>
-        /// Quality of output image. Should be between 0 and 100.
-        /// Only takes effect when image is in jpg or webp format.
-        /// </summary>
-        /// <value>100</value>
-        [Parameter]
-        public int Quality { set; get; } = 100;
-        #endregion
+    }
+
+    /// <summary>
+    ///     Fire when scaling ratio changed by touch event.
+    /// </summary>
+    [Parameter]
+    public EventCallback<double> RatioChanged { get; set; }
+
+    /// <summary>
+    ///     Fire when cropper size changed.
+    ///     Item1 of the return tuple is width, Item2 is height
+    /// </summary>
+    [Parameter]
+    public EventCallback<(double, double)> OnSizeChanged { get; set; }
+
+    /// <summary>
+    ///     Used to set the cropper initial offset position.
+    /// </summary>
+    /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
+    [Parameter]
+    public double OffsetX { set; get; }
+
+    /// <summary>
+    ///     Used to set the cropper initial offset position.
+    /// </summary>
+    /// <remarks>It's unit is not pixel. For more info, see <seealso cref="CropInfo.GetInitParams" /></remarks>
+    [Parameter]
+    public double OffsetY { set; get; }
+
+    /// <summary>
+    ///     Quality of output image. Should be between 0 and 100.
+    ///     Only takes effect when image is in jpg or webp format.
+    /// </summary>
+    /// <value>100</value>
+    [Parameter]
+    public int Quality { set; get; } = 100;
+
+    #endregion
 
 
-        #region public vars
-        /// <summary>
-        /// Min allowed scaling ratio
-        /// </summary>
-        /// <value>1.0</value>
-        public double MinRatio => 1.0;
+    #region public vars
 
-        /// <summary>
-        /// Max allowed scaling ratio
-        /// </summary>
-        /// <remarks>This property is obsolete. Max ratio is no longer limited</remarks>
-        /// <value>2</value>
-        [Obsolete("This property is obsolete. Max ratio is no longer limited")]
-        public double MaxRatio => 2.0;
+    /// <summary>
+    ///     Min allowed scaling ratio
+    /// </summary>
+    /// <value>1.0</value>
+    public double MinRatio => 1.0;
 
-        #endregion
+    /// <summary>
+    ///     Max allowed scaling ratio
+    /// </summary>
+    /// <remarks>This property is obsolete. Max ratio is no longer limited</remarks>
+    /// <value>2</value>
+    [Obsolete("This property is obsolete. Max ratio is no longer limited")]
+    public double MaxRatio => 2.0;
+
+    #endregion
 
 
-        #region internal props
-        internal bool WiderThanContainer
+    #region internal props
+
+    internal bool WiderThanContainer => _image.Width / _image.Height
+                                        > _imgContainerWidth / _imgContainerHeight;
+
+    internal double ImgRealW
+    {
+        get
         {
-            get => (double)_image.Width / (double)_image.Height
-                > _imgContainerWidth / _imgContainerHeight;
+            if (WiderThanContainer)
+                return _imgContainerWidth * _imgSize / 100;
+            return _imgContainerHeight * _imgSize
+                / 100 * _image.Width / _image.Height;
         }
+    }
 
-        internal double ImgRealW
+    internal double ImgRealH
+    {
+        get
         {
-            get
-            {
-                if (WiderThanContainer)
-                {
-                    return _imgContainerWidth * _imgSize / 100;
-                }
-                else
-                {
-                    return _imgContainerHeight * _imgSize
-                        / 100 * (double)_image.Width / _image.Height;
-                }
-            }
+            if (WiderThanContainer)
+                return _imgContainerWidth * _imgSize / 100
+                    * _image.Height / _image.Width;
+            return _imgContainerHeight * _imgSize / 100;
         }
+    }
 
-        internal double ImgRealH
+    internal string BackgroundImgStyle => FormattableString.Invariant($"left:{_bacx}px;top:{_bacy}px;");
+
+    internal string RatioStyle => FormattableString.Invariant($"transform:scale({Ratio});");
+
+    internal string ImglistStyle => FormattableString.Invariant($"height:{CropperHeight}px;");
+
+    #endregion
+
+
+    #region vars
+
+    internal double _prevBacX = 0;
+    internal double _prevBacY = 0;
+    internal double _bacx = 0;
+    internal double _bacy = 0;
+    internal double _imgSize = 100;
+    internal bool _onTwoFingerResizing = false;
+    internal bool _isBacMoving = false;
+    internal double _prevTouchPointDistance = -1;
+    internal double _imgContainerWidth = 500;
+    internal double _imgContainerHeight = 150;
+    internal double _prevPosX = 0;
+    internal double _prevPosY = 0;
+    internal double _layoutX = 0;
+    internal double _layoutY = 0;
+    internal double _offsetX;
+    internal double _offsetY;
+    internal string _cropperStyle = "";
+    internal string _cropedImgStyle = "clip: rect(0, 150px, 150px, 0);";
+    internal bool _dragging = false;
+    internal bool _reSizing = false;
+    internal MoveDir _dir = MoveDir.UnKnown;
+    internal readonly double _minval = 30;
+    internal ImageData _image;
+    internal double _minposX;
+    internal double _minposY;
+    internal double _imgw;
+    internal double _imgh;
+    internal double _unsavedX;
+    internal double _unsavedY;
+    internal double _unsavedCropW;
+    internal double _unsavedCropH;
+    internal IBrowserFile _prevFile;
+    internal IImageFormat _format;
+    internal Image _gifimage;
+    internal double _ratio = 1d;
+    internal bool _evInitialized = false;
+    internal double _minvalx;
+    internal double _minvaly;
+
+    #endregion
+
+
+    #region static actions
+
+    internal static Action _setaction;
+    internal static Action<MouseEventArgs> _mouseMoveAction;
+    internal static Action<MouseEventArgs> _touchMoveAction;
+    internal static Action _touchEndAction;
+    internal static Action _mouseUpAction;
+
+    #endregion
+
+
+    #region Override methods
+
+    /// <inheritdoc />
+    protected override async Task OnInitializedAsync()
+    {
+        await JsRuntime.InvokeVoidAsync("setVersion", Environment.Version.Major);
+    }
+
+    /// <inheritdoc />
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        if (initCropWidth < 0)
         {
-            get
-            {
-                if (WiderThanContainer)
-                {
-                    return _imgContainerWidth * _imgSize / 100
-                        * (double)_image.Height / _image.Width;
-                }
-                else
-                {
-                    return _imgContainerHeight * _imgSize / 100;
-                }
-            }
+            initCropWidth = InitCropWidth;
+            initCropHeight = InitCropHeight;
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        await JsRuntime.InvokeVoidAsync("rmCropperEventListeners");
+    }
+
+    private void InitAspectRatio()
+    {
+        _minvalx = _minval;
+        _minvaly = _minval;
+        if (!RequireAspectRatio)
+            return;
+
+        if (initCropHeight > initCropWidth * AspectRatio)
+        {
+            initCropWidth = initCropHeight / AspectRatio;
+            _minvalx = _minvaly / AspectRatio;
+        }
+        else
+        {
+            initCropHeight = initCropWidth * AspectRatio;
+            _minvaly = _minvalx * AspectRatio;
         }
 
-        internal string BackgroundImgStyle
+        SetCropperStyle();
+        SetCroppedImgStyle();
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnParametersSetAsync()
+    {
+        await base.OnParametersSetAsync();
+        InitAspectRatio();
+        if (_prevFile == ImageFile)
+            return;
+        _prevFile = ImageFile;
+        string ext = ImageFile.Name.Split('.').Last().ToLower();
+        IBrowserFile resizedImageFile = ImageFile;
+        await Task.Delay(10);
+        _gifimage?.Dispose();
+        await LoadImage(ext, resizedImageFile);
+        await InitJSAsync();
+        await SetImgContainterSize();
+        await OnLoad.InvokeAsync();
+        await SizeChanged();
+    }
+
+    private async Task InitJSAsync()
+    {
+        double[] data = { 0, 0 };
+        while (data[0] == 0d)
         {
-            get => FormattableString.Invariant($"left:{_bacx}px;top:{_bacy}px;");
-        }
-        internal string RatioStyle
-        {
-            get => FormattableString.Invariant($"transform:scale({Ratio});");
-        }
-        internal string ImglistStyle
-        {
-            get => FormattableString.Invariant($"height:{CropperHeight}px;");
-        }
-        #endregion
-
-
-        #region vars
-        internal double _prevBacX = 0;
-        internal double _prevBacY = 0;
-        internal double _bacx = 0;
-        internal double _bacy = 0;
-        internal double _imgSize = 100;
-        internal bool _onTwoFingerResizing = false;
-        internal bool _isBacMoving = false;
-        internal double _prevTouchPointDistance = -1;
-        internal double _imgContainerWidth = 500;
-        internal double _imgContainerHeight = 150;
-        internal double _prevPosX = 0;
-        internal double _prevPosY = 0;
-        internal double _layoutX = 0;
-        internal double _layoutY = 0;
-        internal double _offsetX;
-        internal double _offsetY;
-        internal string _cropperStyle = "";
-        internal string _cropedImgStyle = "clip: rect(0, 150px, 150px, 0);";
-        internal bool _dragging = false;
-        internal bool _reSizing = false;
-        internal MoveDir _dir = MoveDir.UnKnown;
-        internal readonly double _minval = 30;
-        internal ImageData _image;
-        internal double _minposX;
-        internal double _minposY;
-        internal double _imgw;
-        internal double _imgh;
-        internal double _unsavedX;
-        internal double _unsavedY;
-        internal double _unsavedCropW;
-        internal double _unsavedCropH;
-        internal IBrowserFile _prevFile;
-        internal IImageFormat _format;
-        internal Image _gifimage;
-        internal double _ratio = 1d;
-        internal bool _evInitialized = false;
-        internal double _minvalx;
-        internal double _minvaly;
-
-        #endregion
-
-
-        #region static actions
-        internal static Action _setaction;
-        internal static Action<MouseEventArgs> _mouseMoveAction;
-        internal static Action<MouseEventArgs> _touchMoveAction;
-        internal static Action _touchEndAction;
-        internal static Action _mouseUpAction;
-        #endregion
-
-
-
-        #region Override methods
-        /// <inheritdoc/>
-        protected override async Task OnInitializedAsync()
-        {
-            await JSRuntime.InvokeVoidAsync("setVersion", Environment.Version.Major);
-        }
-        /// <inheritdoc/>
-        protected override void OnParametersSet()
-        {
-            base.OnParametersSet();
-            if (initCropWidth < 0)
-            {
-                initCropWidth = InitCropWidth;
-                initCropHeight = InitCropHeight;
-            }
-        }
-        /// <inheritdoc/>
-        public async ValueTask DisposeAsync()
-        {
-            await JSRuntime.InvokeVoidAsync("rmCropperEventListeners");
-        }
-
-        private void InitAspectRatio()
-        {
-            _minvalx = _minval;
-            _minvaly = _minval;
-            if (RequireAspectRatio)
-            {
-                if (initCropHeight > initCropWidth * AspectRatio)
-                {
-                    initCropWidth = initCropHeight / AspectRatio;
-                    _minvalx = _minvaly/AspectRatio;
-                }
-                else
-                {
-                    initCropHeight = initCropWidth * AspectRatio;
-                    _minvaly = _minvalx * AspectRatio;
-                }
-                SetCropperStyle();
-                SetCroppedImgStyle();
-            }
-        }
-        /// <inheritdoc/>
-        protected override async Task OnParametersSetAsync()
-        {
-            await base.OnParametersSetAsync();
-            InitAspectRatio();
-            if (_prevFile == ImageFile)
-            {
-                return;
-            }
-            else
-            {
-                _prevFile = ImageFile;
-            }
-            string ext = ImageFile.Name.Split('.').Last().ToLower();
-            IBrowserFile resizedImageFile = ImageFile;
             await Task.Delay(10);
-            _gifimage?.Dispose();
-            await LoadImage(ext, resizedImageFile);
-            await InitJSAsync();
-            await SetImgContainterSize();
-            await OnLoad.InvokeAsync();
-            await SizeChanged();
+            data = await JsRuntime.InvokeAsync<double[]>("getOriImgSize");
         }
 
-        private async Task InitJSAsync()
+        _image = new ImageData
         {
-            double[] data = new double[] { 0, 0 };
-            while (data[0] == 0d)
+            Width = data[0],
+            Height = data[1]
+        };
+        if (!_evInitialized)
+        {
+            await JsRuntime.InvokeVoidAsync("addCropperEventListeners");
+            _evInitialized = true;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool first)
+    {
+        await base.OnAfterRenderAsync(first);
+        if (first)
+        {
+            _setaction = () => SetImgContainterSize();
+            _mouseMoveAction = args =>
             {
-                await Task.Delay(10);
-                data = await JSRuntime.InvokeAsync<double[]>("getOriImgSize");
-            }
-            _image = new ImageData
-            {
-                Width = data[0],
-                Height = data[1]
+                OnSizeChanging(args);
+                OnResizeBackGroundImage(MouseToTouch(args));
             };
-            if (!_evInitialized)
+            _mouseUpAction = () =>
             {
-                await JSRuntime.InvokeVoidAsync("addCropperEventListeners");
-                _evInitialized = true;
-            }
-        }
-        /// <inheritdoc/>
-        protected override async Task OnAfterRenderAsync(bool first)
-        {
-            await base.OnAfterRenderAsync(first);
-            if (first)
-            {
-                _setaction = () => SetImgContainterSize();
-                _mouseMoveAction = args =>
+                if (_onTwoFingerResizing || _isBacMoving)
                 {
-                    OnSizeChanging(args);
-                    OnResizeBackGroundImage(MouseToTouch(args));
-                };
-                _mouseUpAction = () =>
-                {
-                    if (_onTwoFingerResizing || _isBacMoving)
-                    {
-                        _isBacMoving = false;
-                        _onTwoFingerResizing = false;
-                        InitBox();
-                    }
-                    OnSizeChangeEnd();
-                };
-                _touchMoveAction = OnSizeChanging;
-                _touchEndAction = () =>
-                {
-                    OnSizeChangeEnd();
-                };
-            }
-        }
-        #endregion
-
-        #region JsInvokable methods
-        [JSInvokable("OnTouchEnd")]
-        public static void TouchEndCaller()
-        {
-            _touchEndAction?.Invoke();
-        }
-        [JSInvokable("OnTouchMove")]
-        public static void TouchMoveCaller(MouseEventArgs args)
-        {
-            _touchMoveAction?.Invoke(args);
-        }
-        [JSInvokable("OnMouseUp")]
-        public static void MouseUpCaller()
-        {
-            _mouseUpAction?.Invoke();
-        }
-        [JSInvokable("OnMouseMove")]
-        public static void MouseMoveCaller(MouseEventArgs args)
-        {
-            _mouseMoveAction?.Invoke(args);
-        }
-        [JSInvokable("SetWidthHeight")]
-        public static void SetWidthHeightCaller()
-        {
-            _setaction?.Invoke();
-        }
-        #endregion
-
-
-        #region Public methods
-        /// <summary>
-        /// Get the crop result.
-        /// </summary>
-        /// <returns>crop result</returns>
-        public async Task<ImageCroppedResult> GetCropedResult()
-        {
-
-            var info = GetCropInfo();
-            var rect = info.Rectangle;
-            var (x, y, proportionalCropWidth, proportionalCropHeight, resizeProp) = (rect.X, rect.Y, rect.Width, rect.Height, info.ResizeProp);
-            if (_gifimage == null)
-            {
-                if (Environment.Version.Major > 5)
-                {
-                    // for dotnet version after 5, pass byte array between c# and js is optimized
-                    // async function cropAsync(id, sx, sy, swidth, sheight, x, y, width, height, format)
-                    var bin = await JSRuntime.InvokeAsync<byte[]>("cropAsync", "oriimg",
-                        x, y, (proportionalCropWidth), (proportionalCropHeight), 0, 0,
-                        proportionalCropWidth, proportionalCropHeight, _format.DefaultMimeType, Quality);
-                    return new ImageCroppedResult(bin, _format);
+                    _isBacMoving = false;
+                    _onTwoFingerResizing = false;
+                    InitBox();
                 }
-                else
-                {
-                    // async function cropAsync(id, sx, sy, swidth, sheight, x, y, width, height, format)
-                    string s = await JSRuntime.InvokeAsync<string>("cropAsync", "oriimg",
-                        x, y, (proportionalCropWidth), (proportionalCropHeight), 0, 0,
-                        proportionalCropWidth, proportionalCropHeight, _format.DefaultMimeType, Quality);
-                    return new ImageCroppedResult(s, _format);
-                }
-            }
-            else
+
+                OnSizeChangeEnd();
+            };
+            _touchMoveAction = OnSizeChanging;
+            _touchEndAction = () => { OnSizeChangeEnd(); };
+        }
+    }
+
+    #endregion
+
+    #region JsInvokable methods
+
+    [JSInvokable("OnTouchEnd")]
+    public static void TouchEndCaller()
+    {
+        _touchEndAction?.Invoke();
+    }
+
+    [JSInvokable("OnTouchMove")]
+    public static void TouchMoveCaller(MouseEventArgs args)
+    {
+        _touchMoveAction?.Invoke(args);
+    }
+
+    [JSInvokable("OnMouseUp")]
+    public static void MouseUpCaller()
+    {
+        _mouseUpAction?.Invoke();
+    }
+
+    [JSInvokable("OnMouseMove")]
+    public static void MouseMoveCaller(MouseEventArgs args)
+    {
+        _mouseMoveAction?.Invoke(args);
+    }
+
+    [JSInvokable("SetWidthHeight")]
+    public static void SetWidthHeightCaller()
+    {
+        _setaction?.Invoke();
+    }
+
+    #endregion
+
+
+    #region Public methods
+
+    /// <summary>
+    ///     Get the crop result.
+    /// </summary>
+    /// <returns>crop result</returns>
+    public async Task<ImageCroppedResult> GetCropedResult()
+    {
+        CropInfo info = GetCropInfo();
+        Rectangle rect = info.Rectangle;
+        (int x, int y, int proportionalCropWidth, int proportionalCropHeight, double resizeProp) =
+            (rect.X, rect.Y, rect.Width, rect.Height, info.ResizeProp);
+        if (_gifimage == null)
+        {
+            if (Environment.Version.Major > 5)
             {
-                _gifimage.Mutate(ctx =>
-                {
-                    // fix exif orientaion issue
-                    ctx.AutoOrient();
-                    ctx.Crop(rect);
-                    if (resizeProp != 1d)
-                    {
-                        ctx.Resize(new Size(proportionalCropWidth, proportionalCropHeight));
-                    }
-                });
-                return new ImageCroppedResult(_gifimage, _format, Quality);
+                // for dotnet version after 5, pass byte array between c# and js is optimized
+                // async function cropAsync(id, sx, sy, swidth, sheight, x, y, width, height, format)
+                byte[] bin = await JsRuntime.InvokeAsync<byte[]>("cropAsync", "oriimg",
+                    x, y, proportionalCropWidth, proportionalCropHeight, 0, 0,
+                    proportionalCropWidth, proportionalCropHeight, _format.DefaultMimeType, Quality);
+                return new ImageCroppedResult(bin, _format);
             }
+
+            // async function cropAsync(id, sx, sy, swidth, sheight, x, y, width, height, format)
+            string s = await JsRuntime.InvokeAsync<string>("cropAsync", "oriimg",
+                x, y, proportionalCropWidth, proportionalCropHeight, 0, 0,
+                proportionalCropWidth, proportionalCropHeight, _format.DefaultMimeType, Quality);
+            return new ImageCroppedResult(s, _format);
         }
 
-        /// <summary>
-        /// Returns the metadata about the cropper state.
-        /// </summary>
-        /// <returns></returns>
-        public CropInfo GetCropInfo()
+        _gifimage.Mutate(ctx =>
         {
-            double deltaX = 0;
-            double deltaY = 0;
-            var (resizeProp, width, height) = GetCropperInfos();
-            if (WiderThanContainer)
-            {
-                deltaY = -(_imgContainerHeight - _image.Height / resizeProp) / 2;
-            }
-            else
-            {
-                deltaX = -(_imgContainerWidth - _image.Width / resizeProp) / 2;
-            }
-            double x = ((_prevPosX - _bacx) + deltaX);
-            double y = ((_prevPosY - _bacy) + deltaY);
+            // fix exif orientaion issue
+            ctx.AutoOrient();
+            ctx.Crop(rect);
+            if (resizeProp != 1d) ctx.Resize(new Size(proportionalCropWidth, proportionalCropHeight));
+        });
+        return new ImageCroppedResult(_gifimage, _format, Quality);
+    }
+
+    /// <summary>
+    ///     Returns the metadata about the cropper state.
+    /// </summary>
+    /// <returns></returns>
+    public CropInfo GetCropInfo()
+    {
+        double deltaX = 0;
+        double deltaY = 0;
+        (double resizeProp, double width, double height) = GetCropperInfos();
+        if (WiderThanContainer)
+            deltaY = -(_imgContainerHeight - _image.Height / resizeProp) / 2;
+        else
+            deltaX = -(_imgContainerWidth - _image.Width / resizeProp) / 2;
+        double x = _prevPosX - _bacx + deltaX;
+        double y = _prevPosY - _bacy + deltaY;
 
 
-            return new CropInfo
-            {
-                Rectangle = new Rectangle((int)(x * resizeProp), (int)(y * resizeProp),
+        return new CropInfo
+        {
+            Rectangle = new Rectangle((int)(x * resizeProp), (int)(y * resizeProp),
                 (int)(width * resizeProp), (int)(height * resizeProp)),
-                Ratio = Ratio,
-                ResizeProp = resizeProp
-            };
-        }
+            Ratio = Ratio,
+            ResizeProp = resizeProp
+        };
+    }
 
-        #endregion
+    #endregion
 
 
-        #region internal methods
+    #region internal methods
 
-        internal string GetCropperStyle(double top, double left, double height, double width)
-        {
-            return FormattableString.Invariant($"top:{top}px;left:{left}px;height:{height}px;width:{width}px;");
-        }
+    internal string GetCropperStyle(double top, double left, double height, double width)
+        => FormattableString.Invariant($"top:{top}px;left:{left}px;height:{height}px;width:{width}px;");
 
-        internal string GetCroppedImgStyle(double top, double right, double bottom, double left)
-        {
-            return FormattableString.Invariant($"clip: rect({top}px, {right}px, {bottom}px, {left}px);");
-        }
+    internal string GetCroppedImgStyle(double top, double right, double bottom, double left)
+        => FormattableString.Invariant($"clip: rect({top}px, {right}px, {bottom}px, {left}px);");
 
-        internal (double resizeProp, double cw, double ch) GetCropperInfos()
-        {
-            double resizeProp = 1d;
-            double cw = (initCropWidth);
-            double ch = (initCropHeight);
-            if (WiderThanContainer)
+    internal (double resizeProp, double cw, double ch) GetCropperInfos()
+    {
+        double resizeProp = 1d;
+        double cw = initCropWidth;
+        double ch = initCropHeight;
+        if (WiderThanContainer)
+            resizeProp = _image.Width / _imgContainerWidth;
+        else
+            resizeProp = _image.Height / _imgContainerHeight;
+        return (resizeProp, cw, ch);
+    }
+
+
+    internal void SetCroppedImgStyle()
+    {
+        _cropedImgStyle = GetCroppedImgStyle(_prevPosY - _layoutY, _prevPosX - _layoutX + initCropWidth, _prevPosY - _layoutY + initCropHeight,
+            _prevPosX - _layoutX);
+    }
+
+    internal void SetCropperStyle()
+    {
+        _cropperStyle = GetCropperStyle(_prevPosY, _prevPosX, initCropHeight, initCropWidth);
+    }
+
+    internal void TouchToMouse(TouchEventArgs args, Action<MouseEventArgs> handler)
+    {
+        if (args != null && args.Touches != null && args.Touches.Length > 0) //TODO args.Touches != null is never null
+            handler(new MouseEventArgs
             {
-                resizeProp = _image.Width / _imgContainerWidth;
-            }
-            else
+                ClientX = args.Touches[0].ClientX,
+                ClientY = args.Touches[0].ClientY
+            });
+    }
+
+    internal void OnDragStart(MouseEventArgs args)
+    {
+        if (_reSizing) return;
+        SetCropperStyle();
+        _offsetX = args.ClientX;
+        _offsetY = args.ClientY;
+        _dragging = true;
+    }
+
+    internal void OnDragging(MouseEventArgs args)
+    {
+        if (!_dragging || _reSizing)
+            return;
+
+        double x = _prevPosX - (_offsetX - args.ClientX) / Ratio;
+        double y = _prevPosY - (_offsetY - args.ClientY) / Ratio;
+        if (y < _minposY) y = _minposY;
+        if (x < _minposX) x = _minposX;
+        if (y + initCropHeight > _minposY + _imgh) y = _minposY + _imgh - initCropHeight;
+        if (x + initCropWidth > _minposX + _imgw) x = _minposX + _imgw - initCropWidth;
+        _unsavedX = x;
+        _unsavedY = y;
+
+        _cropperStyle = GetCropperStyle(y, x, initCropHeight, initCropWidth);
+        _cropedImgStyle = GetCroppedImgStyle(y - _layoutY, x - _layoutX + initCropWidth, y - _layoutY + initCropHeight, x - _layoutX);
+        StateHasChanged();
+    }
+
+    internal void OnDragEnd()
+    {
+        _dragging = false;
+        _prevPosX = _unsavedX;
+        _prevPosY = _unsavedY;
+    }
+
+    internal void OnResizeStart(MouseEventArgs args, MoveDir dir)
+    {
+        _dir = dir;
+        if (_dragging)
+            return;
+
+        SetCropperStyle();
+        _offsetX = args.ClientX;
+        _offsetY = args.ClientY;
+        if (IsCropLocked && !_isBacMoving && !_onTwoFingerResizing)
+        {
+            OnDragStart(args);
+            return;
+        }
+
+        _reSizing = true;
+    }
+
+    internal async ValueTask LoadImage(string ext, IBrowserFile resizedImageFile)
+    {
+        if (PureCSharpProcessing || string.IsNullOrEmpty(InputId) || (ext == "gif" && AnimeGifEnable))
+        {
+            byte[] buffer = new byte[resizedImageFile.Size];
+            if (Environment.Version.Major == 6)
             {
-                resizeProp = _image.Height / _imgContainerHeight;
-            }
-            return (resizeProp, cw, ch);
-        }
-
-
-        internal void SetCroppedImgStyle()
-        {
-            _cropedImgStyle = GetCroppedImgStyle(_prevPosY - _layoutY, _prevPosX - _layoutX + initCropWidth, _prevPosY - _layoutY + initCropHeight, _prevPosX - _layoutX);
-        }
-
-        internal void SetCropperStyle()
-        {
-            _cropperStyle = GetCropperStyle(_prevPosY, _prevPosX, initCropHeight, initCropWidth);
-        }
-
-        internal void TouchToMouse(TouchEventArgs args, Action<MouseEventArgs> handler)
-        {
-            if (args != null && args.Touches != null && args.Touches.Length > 0)
-            {
-                handler(new MouseEventArgs
-                {
-                    ClientX = args.Touches[0].ClientX,
-                    ClientY = args.Touches[0].ClientY
-                });
-            }
-        }
-
-        internal void OnDragStart(MouseEventArgs args)
-        {
-            if (_reSizing)
-            {
-                return;
-            }
-            SetCropperStyle();
-            _offsetX = args.ClientX;
-            _offsetY = args.ClientY;
-            _dragging = true;
-        }
-
-        internal void OnDragging(MouseEventArgs args)
-        {
-            if (_dragging && !_reSizing)
-            {
-                double x = _prevPosX - (_offsetX - args.ClientX) / Ratio;
-                double y = _prevPosY - (_offsetY - args.ClientY) / Ratio;
-                if (y < _minposY)
-                {
-                    y = _minposY;
-                }
-                if (x < _minposX)
-                {
-                    x = _minposX;
-                }
-                if (y + initCropHeight > (_minposY + _imgh))
-                {
-                    y = (_minposY + _imgh) - initCropHeight;
-                }
-                if (x + initCropWidth > (_minposX + _imgw))
-                {
-                    x = (_minposX + _imgw) - initCropWidth;
-                }
-                _unsavedX = x;
-                _unsavedY = y;
-
-                _cropperStyle = GetCropperStyle(y, x, initCropHeight, initCropWidth);
-                _cropedImgStyle = GetCroppedImgStyle(y - _layoutY, x - _layoutX + initCropWidth, y - _layoutY + initCropHeight, x - _layoutX);
-                base.StateHasChanged();
-            }
-        }
-
-        internal void OnDragEnd()
-        {
-            _dragging = false;
-            _prevPosX = _unsavedX;
-            _prevPosY = _unsavedY;
-        }
-
-        internal void OnResizeStart(MouseEventArgs args, MoveDir dir)
-        {
-            this._dir = dir;
-            if (_dragging)
-            {
-                return;
-            }
-            SetCropperStyle();
-            _offsetX = args.ClientX;
-            _offsetY = args.ClientY;
-            if (IsCropLocked && !_isBacMoving && !_onTwoFingerResizing)
-            {
-                OnDragStart(args);
-                return;
-            }
-            _reSizing = true;
-        }
-
-        internal async ValueTask LoadImage(string ext, IBrowserFile resizedImageFile)
-        {
-            if (PureCSharpProcessing || string.IsNullOrEmpty(InputId) || (ext == "gif" && AnimeGifEnable))
-            {
-                byte[] buffer = new byte[resizedImageFile.Size];
-                if (Environment.Version.Major == 6)
-                {
-                    var isClientSide = JSRuntime is IJSInProcessRuntime;
-                    if (isClientSide)
-                    {
-                        await resizedImageFile.OpenReadStream(1024 * 1024 * 90).ReadAsync(buffer);
-                    }
-                    else
-                    {
-                        // WORKAROUND https://github.com/Chronostasys/Blazor.Cropper/issues/43
-                        var fileContent = new StreamContent(resizedImageFile.OpenReadStream(1024 * 1024 * 90));
-                        buffer = await fileContent.ReadAsByteArrayAsync();
-                    }
-                }
-                else
+                bool isClientSide = JsRuntime is IJSInProcessRuntime;
+                if (isClientSide)
                 {
                     await resizedImageFile.OpenReadStream(1024 * 1024 * 90).ReadAsync(buffer);
                 }
-                if ((ext == "gif" && AnimeGifEnable) || PureCSharpProcessing)
-                {
-                    _gifimage = Image.Load(buffer, out _format);
-                    await JSRuntime.InvokeVoidAsync("setImgSrc", buffer, _format.DefaultMimeType);
-                }
                 else
                 {
-
-                    var m = Configuration.Default.ImageFormatsManager;
-
-                    _format = m.FindFormatByFileExtension(ext) ?? PngFormat.Instance;
-                    await JSRuntime.InvokeVoidAsync("setImgSrc", buffer, "image/" + ext);
+                    // WORKAROUND https://github.com/Chronostasys/Blazor.Cropper/issues/43
+                    StreamContent fileContent = new(resizedImageFile.OpenReadStream(1024 * 1024 * 90));
+                    buffer = await fileContent.ReadAsByteArrayAsync();
                 }
             }
             else
             {
-                await JSRuntime.InvokeVoidAsync("setImg", InputId);
+                await resizedImageFile.OpenReadStream(1024 * 1024 * 90).ReadAsync(buffer);
             }
-        }
 
-        internal void OnSizeChanging(MouseEventArgs args)
-        {
-            if (_reSizing && !_dragging)
+            if ((ext == "gif" && AnimeGifEnable) || PureCSharpProcessing)
             {
-                double deltaY = (args.ClientY - _offsetY) / Ratio;
-                double deltaX = (args.ClientX - _offsetX) / Ratio;
-                var cb = new CropBox(this);
-                cb.DragCorner(deltaX, deltaY,_dir);
-                _unsavedX = cb.X;
-                _unsavedY = cb.Y;
-                _unsavedCropH = cb.H;
-                _unsavedCropW = cb.W;
-                _cropperStyle = GetCropperStyle(cb.Y, cb.X, cb.H, cb.W);
-                _cropedImgStyle = GetCroppedImgStyle(cb.Y - _layoutY, cb.X - _layoutX + cb.W, cb.Y - _layoutY + cb.H, cb.X - _layoutX);
-            }
-            OnDragging(args);
-            base.StateHasChanged();
-        }
-
-        internal void OnSizeChangeEnd()
-        {
-            if (_reSizing)
-            {
-                _reSizing = false;
-                initCropHeight = _unsavedCropH;
-                initCropWidth = _unsavedCropW;
-                _prevPosY = _unsavedY;
-                _prevPosX = _unsavedX;
-                SizeChanged();
-                return;
-            }
-            if (_dragging)
-            {
-                OnDragEnd();
-            }
-            SizeChanged();
-        }
-
-        internal Task SizeChanged()
-        {
-            var (resizeProp, cw, ch) = GetCropperInfos();
-            return OnSizeChanged.InvokeAsync((cw * resizeProp, ch * resizeProp));
-        }
-
-        internal TouchEventArgs MouseToTouch(MouseEventArgs args)
-        {
-            return new TouchEventArgs
-            {
-                Touches = new[]
-                {
-                    new TouchPoint
-                    {
-                        ClientX = args.ClientX,
-                        ClientY = args.ClientY
-                    }
-                }
-            };
-        }
-        internal void GuardImgPosition()
-        {
-            if (WiderThanContainer)
-            {
-                _minposX = 0;
-                _minposY = (_imgContainerHeight - ImgRealH) / 2;
+                _gifimage = Image.Load(buffer, out _format);
+                await JsRuntime.InvokeVoidAsync("setImgSrc", buffer, _format.DefaultMimeType);
             }
             else
             {
-                _minposY = 0;
-                _minposX = (_imgContainerWidth - ImgRealW) / 2;
+                ImageFormatManager m = Configuration.Default.ImageFormatsManager;
+
+                _format = m.FindFormatByFileExtension(ext) ?? PngFormat.Instance;
+                await JsRuntime.InvokeVoidAsync("setImgSrc", buffer, "image/" + ext);
             }
         }
-        internal void ResizeBac(double i)
+        else
         {
-            double temp = _imgSize;
-            if (_imgSize * i < 100 && i < 1 ||
-                ((ImgRealW * i > _imgContainerWidth) && (ImgRealH * i > _imgContainerHeight) && i > 1))
-                return;
-            _imgSize *= i;
-            GuardImgPosition();
-            _minposY += _bacy - (_imgSize - temp) / _imgSize * ImgRealH / 2;
-            _minposX += _bacx;
-            if (_prevPosX + initCropWidth > _minposX + ImgRealW || _prevPosX < _minposX
-                || _prevPosY + initCropHeight > _minposY + ImgRealH || _prevPosY < _minposY)
-                _imgSize /= i;
-            else
-            {
-                _bacy -= (i - 1) * ImgRealH / 2;
-                _layoutY -= (i - 1) * ImgRealH / 2;
-                SetCroppedImgStyle();
-            }
+            await JsRuntime.InvokeVoidAsync("setImg", InputId);
         }
-
-        internal void OnResizeBackGroundImage(TouchEventArgs args)
-        {
-            if (args.Touches.Length == 1)
-            {
-                if (!_isBacMoving)
-                {
-                    return;
-                }
-                double dx = (args.Touches[0].ClientX - _prevBacX) / Ratio;
-                double dy = (args.Touches[0].ClientY - _prevBacY) / Ratio;
-                GuardImgPosition();
-                _minposY += _bacy + dy;
-                _minposX += _bacx + dx;
-                _bacx += dx;
-                _bacy += dy;
-                _layoutX += dx;
-                _layoutY += dy;
-                if (_prevPosX + initCropWidth > _minposX + ImgRealW || _prevPosX < _minposX)
-                {
-                    _bacx -= dx;
-                    _layoutX -= dx;
-                    _minposX -= _bacx;
-                }
-                if (_prevPosY + initCropHeight > _minposY + ImgRealH || _prevPosY < _minposY)
-                {
-                    _bacy -= dy;
-                    _layoutY -= dy;
-                    _minposY -= _bacy;
-                }
-                SetCroppedImgStyle();
-                _prevBacX = args.Touches[0].ClientX;
-                _prevBacY = args.Touches[0].ClientY;
-            }
-            if (args.Touches.Length != 2 || IsImageLocked)
-            {
-                return;
-            }
-            // two finger resize
-            double distance = Math.Pow((args.Touches[0].ClientX - args.Touches[1].ClientX), 2) +
-                Math.Pow((args.Touches[0].ClientY - args.Touches[1].ClientY), 2);
-            if (_onTwoFingerResizing)
-            {
-                double i = distance / _prevTouchPointDistance;
-                ResizeBac(i);
-                Ratio = _imgSize / 100;
-            }
-            else
-            {
-                _onTwoFingerResizing = true;
-            }
-            _prevTouchPointDistance = distance;
-
-        }
-
-        internal async Task SetImgContainterSize()
-        {
-            double[] t = await JSRuntime.InvokeAsync<double[]>("getWidthHeight");
-            // in the case that container has not yet loaded 
-            while (t[0] == 0)
-            {
-                await Task.Delay(10);
-                t = await JSRuntime.InvokeAsync<double[]>("getWidthHeight");
-            }
-            _imgContainerWidth = t[0];
-            _imgContainerHeight = t[1];
-            InitStyles();
-        }
-
-        internal void InitBox()
-        {
-            double prevPosX = 0d, prevPosY = 0d;
-
-            InitPos(ref prevPosX, ref prevPosY);
-        }
-        internal void InitPos(ref double prevPosX, ref double prevPosY)
-        {
-            if (WiderThanContainer)
-            {
-                prevPosY = (_imgContainerHeight - ImgRealH) / 2;
-                prevPosX = 0;
-            }
-            else
-            {
-                prevPosX = Math.Abs(_imgContainerWidth - ImgRealW) / 2;
-                prevPosY = 0;
-            }
-            prevPosY += _bacy;
-            prevPosX += _bacx;
-            _minposX = prevPosX;
-            _minposY = prevPosY;
-            _imgw = ImgRealW;
-            _imgh = ImgRealH;
-        }
-
-        internal void InitStyles()
-        {
-            InitPos(ref _prevPosX, ref _prevPosY);
-            _prevPosX += OffsetX;
-            _prevPosY += OffsetY;
-
-            if (initCropHeight > _imgh)
-            {
-                initCropHeight = _imgh;
-            }
-            if (initCropWidth > _imgw)
-            {
-                initCropWidth = _imgw;
-            }
-
-            SetCropperStyle();
-            SetCroppedImgStyle();
-            base.StateHasChanged();
-        }
-        #endregion
     }
+
+    internal void OnSizeChanging(MouseEventArgs args)
+    {
+        if (_reSizing && !_dragging)
+        {
+            double deltaY = (args.ClientY - _offsetY) / Ratio;
+            double deltaX = (args.ClientX - _offsetX) / Ratio;
+            CropBox cb = new(this);
+            cb.DragCorner(deltaX, deltaY, _dir);
+            _unsavedX = cb.X;
+            _unsavedY = cb.Y;
+            _unsavedCropH = cb.H;
+            _unsavedCropW = cb.W;
+            _cropperStyle = GetCropperStyle(cb.Y, cb.X, cb.H, cb.W);
+            _cropedImgStyle = GetCroppedImgStyle(cb.Y - _layoutY, cb.X - _layoutX + cb.W, cb.Y - _layoutY + cb.H, cb.X - _layoutX);
+        }
+
+        OnDragging(args);
+        StateHasChanged();
+    }
+
+    internal void OnSizeChangeEnd()
+    {
+        if (_reSizing)
+        {
+            _reSizing = false;
+            initCropHeight = _unsavedCropH;
+            initCropWidth = _unsavedCropW;
+            _prevPosY = _unsavedY;
+            _prevPosX = _unsavedX;
+            SizeChanged();
+            return;
+        }
+
+        if (_dragging) OnDragEnd();
+        SizeChanged();
+    }
+
+    internal Task SizeChanged()
+    {
+        (double resizeProp, double cw, double ch) = GetCropperInfos();
+        return OnSizeChanged.InvokeAsync((cw * resizeProp, ch * resizeProp));
+    }
+
+    internal TouchEventArgs MouseToTouch(MouseEventArgs args)
+    {
+        return new TouchEventArgs
+        {
+            Touches = new[]
+            {
+                new TouchPoint
+                {
+                    ClientX = args.ClientX,
+                    ClientY = args.ClientY
+                }
+            }
+        };
+    }
+
+    internal void GuardImgPosition()
+    {
+        if (WiderThanContainer)
+        {
+            _minposX = 0;
+            _minposY = (_imgContainerHeight - ImgRealH) / 2;
+        }
+        else
+        {
+            _minposY = 0;
+            _minposX = (_imgContainerWidth - ImgRealW) / 2;
+        }
+    }
+
+    internal void ResizeBac(double i)
+    {
+        double temp = _imgSize;
+        if ((_imgSize * i < 100 && i < 1) ||
+            (ImgRealW * i > _imgContainerWidth && ImgRealH * i > _imgContainerHeight && i > 1))
+            return;
+        _imgSize *= i;
+        GuardImgPosition();
+        _minposY += _bacy - (_imgSize - temp) / _imgSize * ImgRealH / 2;
+        _minposX += _bacx;
+        if (_prevPosX + initCropWidth > _minposX + ImgRealW || _prevPosX < _minposX
+                                                            || _prevPosY + initCropHeight > _minposY + ImgRealH || _prevPosY < _minposY)
+        {
+            _imgSize /= i;
+        }
+        else
+        {
+            _bacy -= (i - 1) * ImgRealH / 2;
+            _layoutY -= (i - 1) * ImgRealH / 2;
+            SetCroppedImgStyle();
+        }
+    }
+
+    internal void OnResizeBackGroundImage(TouchEventArgs args)
+    {
+        if (args.Touches.Length == 1)
+        {
+            if (!_isBacMoving) return;
+            double dx = (args.Touches[0].ClientX - _prevBacX) / Ratio;
+            double dy = (args.Touches[0].ClientY - _prevBacY) / Ratio;
+            GuardImgPosition();
+            _minposY += _bacy + dy;
+            _minposX += _bacx + dx;
+            _bacx += dx;
+            _bacy += dy;
+            _layoutX += dx;
+            _layoutY += dy;
+            if (_prevPosX + initCropWidth > _minposX + ImgRealW || _prevPosX < _minposX)
+            {
+                _bacx -= dx;
+                _layoutX -= dx;
+                _minposX -= _bacx;
+            }
+
+            if (_prevPosY + initCropHeight > _minposY + ImgRealH || _prevPosY < _minposY)
+            {
+                _bacy -= dy;
+                _layoutY -= dy;
+                _minposY -= _bacy;
+            }
+
+            SetCroppedImgStyle();
+            _prevBacX = args.Touches[0].ClientX;
+            _prevBacY = args.Touches[0].ClientY;
+        }
+
+        if (args.Touches.Length != 2 || IsImageLocked) return;
+        // two finger resize
+        double distance = Math.Pow(args.Touches[0].ClientX - args.Touches[1].ClientX, 2) +
+                          Math.Pow(args.Touches[0].ClientY - args.Touches[1].ClientY, 2);
+        if (_onTwoFingerResizing)
+        {
+            double i = distance / _prevTouchPointDistance;
+            ResizeBac(i);
+            Ratio = _imgSize / 100;
+        }
+        else
+        {
+            _onTwoFingerResizing = true;
+        }
+
+        _prevTouchPointDistance = distance;
+    }
+
+    internal async Task SetImgContainterSize()
+    {
+        double[] t = await JsRuntime.InvokeAsync<double[]>("getWidthHeight");
+        // in the case that container has not yet loaded 
+        while (t[0] == 0)
+        {
+            await Task.Delay(10);
+            t = await JsRuntime.InvokeAsync<double[]>("getWidthHeight");
+        }
+
+        _imgContainerWidth = t[0];
+        _imgContainerHeight = t[1];
+        InitStyles();
+    }
+
+    internal void InitBox()
+    {
+        double prevPosX = 0d, prevPosY = 0d;
+
+        InitPos(ref prevPosX, ref prevPosY);
+    }
+
+    internal void InitPos(ref double prevPosX, ref double prevPosY)
+    {
+        if (WiderThanContainer)
+        {
+            prevPosY = (_imgContainerHeight - ImgRealH) / 2;
+            prevPosX = 0;
+        }
+        else
+        {
+            prevPosX = Math.Abs(_imgContainerWidth - ImgRealW) / 2;
+            prevPosY = 0;
+        }
+
+        prevPosY += _bacy;
+        prevPosX += _bacx;
+        _minposX = prevPosX;
+        _minposY = prevPosY;
+        _imgw = ImgRealW;
+        _imgh = ImgRealH;
+    }
+
+    internal void InitStyles()
+    {
+        InitPos(ref _prevPosX, ref _prevPosY);
+        _prevPosX += OffsetX;
+        _prevPosY += OffsetY;
+
+        if (initCropHeight > _imgh) initCropHeight = _imgh;
+        if (initCropWidth > _imgw) initCropWidth = _imgw;
+
+        SetCropperStyle();
+        SetCroppedImgStyle();
+        StateHasChanged();
+    }
+
+    #endregion
 }

--- a/Blazor.Cropper/ImageCroppedResult.cs
+++ b/Blazor.Cropper/ImageCroppedResult.cs
@@ -3,145 +3,130 @@ using System.IO;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.Formats.Bmp;
-using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
-using SixLabors.ImageSharp.Formats.Tiff;
 using SixLabors.ImageSharp.Formats.Webp;
-using SixLabors.ImageSharp.Formats.Tga;
-using SixLabors.ImageSharp.Formats.Pbm;
 
-namespace Blazor.Cropper
+namespace Blazor.Cropper;
+
+public class ImageCroppedResult : IDisposable
 {
-    public class ImageCroppedResult : IDisposable
+    private readonly string _base64;
+    private byte[] _data;
+
+    public ImageCroppedResult(Image img, IImageFormat format, int quality)
     {
-        private readonly string _base64;
-        private byte[] _data;
-        public Image Img { get; init; }
-        public IImageFormat Format { get; init; }
-        public int Quality { get; init; }
-        public ImageCroppedResult(Image img, IImageFormat format, int quality)
-        {
-            Img = img;
-            Format = format;
-            Quality = quality;
-        }
-        public ImageCroppedResult(string base64, IImageFormat format)
-        {
-            _base64 = base64;
-            Format = format;
-        }
+        Img = img;
+        Format = format;
+        Quality = quality;
+    }
 
-        public ImageCroppedResult(byte[] bytes, IImageFormat format)
-        {
-            _data = bytes;
-            Format = format;
-        }
+    public ImageCroppedResult(string base64, IImageFormat format)
+    {
+        _base64 = base64;
+        Format = format;
+    }
+
+    public ImageCroppedResult(byte[] bytes, IImageFormat format)
+    {
+        _data = bytes;
+        Format = format;
+    }
+
+    public Image Img { get; init; }
+    public IImageFormat Format { get; init; }
+    public int Quality { get; init; }
+
+    public void Dispose()
+    {
+        Img?.Dispose();
+    }
 #if NET6_0_OR_GREATER
-        [Obsolete("this api is obsolete in dotnet 6 for bad performance")]
+    [Obsolete("this api is obsolete in dotnet 6 for bad performance")]
 #endif
-        public async Task<string> GetBase64Async()
-        {
-            if (_base64!=null)
-            {
-                return _base64;
-            }
-            return Convert.ToBase64String(await GetDataAsync());
-        }
-        /// <summary>
-        /// get image bytes
-        /// </summary>
-        /// <returns>image bytes</returns>
-        /// <exception cref="InvalidOperationException"></exception>
-        public async Task<byte[]> GetDataAsync()
-        {
-            if (_data!=null)
-            {
-                return _data;
-            }
-            if (_base64!=null)
-            {
-                _data = Convert.FromBase64String(_base64);
-                return _data;
-            }
-            if (Img!=null)
-            {
-                using MemoryStream memoryStream = new MemoryStream();
-                var encoder = GetImageEncoder(Format, Quality);
-                await Img.SaveAsync(memoryStream, encoder);
+    public async Task<string> GetBase64Async()
+    {
+        return _base64 ?? Convert.ToBase64String(await GetDataAsync());
+    }
 
-                _data = memoryStream.ToArray();
-                return _data;
-            }
-            throw new InvalidOperationException();
-        }
-        /// <summary>
-        /// save img data to stream
-        /// </summary>
-        /// <param name="s"></param>
-        /// <returns></returns>
-        public Task SaveAsync(Stream s)
+    /// <summary>
+    ///     get image bytes
+    /// </summary>
+    /// <returns>image bytes</returns>
+    /// <exception cref="InvalidOperationException"></exception>
+    public async Task<byte[]> GetDataAsync()
+    {
+        if (_data != null) return _data;
+        if (_base64 != null)
         {
-            if (Img != null)
-            {
-
-                var encoder = GetImageEncoder(Format, Quality);
-                return Img.SaveAsync(s, encoder);
-            }
-            if (_data!=null)
-            {
-                return s.WriteAsync(_data).AsTask();
-            }
-            if (_base64!=null)
-            {
-                _data = Convert.FromBase64String(_base64);
-                return s.WriteAsync(_data).AsTask();
-            }
-            throw new InvalidOperationException();
+            _data = Convert.FromBase64String(_base64);
+            return _data;
         }
 
-        private IImageEncoder GetImageEncoder(IImageFormat format, int quality)
+        if (Img != null)
         {
-            var encoder = Configuration.Default.ImageFormatsManager.FindEncoder(Format);
-            switch (encoder)
-            {
-                case JpegEncoder e:
-                    e.Quality = Quality;
-                    break;
-                case WebpEncoder e:
-                    e.Quality = Quality;
-                    break;
-                default:
-                    break;
-            }
-            return encoder;
+            using MemoryStream memoryStream = new MemoryStream();
+            IImageEncoder encoder = GetImageEncoder(Format, Quality);
+            await Img.SaveAsync(memoryStream, encoder);
+
+            _data = memoryStream.ToArray();
+            return _data;
         }
 
-#if NET6_0_OR_GREATER
-        /// <summary>
-        /// Save image to a stream with your own
-        /// <see cref="IImageEncoder"/>.
-        /// This can be use to
-        /// set some advanced options e.g. <see cref="PngCompressionLevel"/> for png.
-        /// This method can only be used when the cropper working in pure cs mode
-        /// </summary>
-        /// <param name="s"></param>
-        /// <param name="encoder"></param>
-        /// <returns></returns>
-        public Task SaveAsync(Stream s, IImageEncoder encoder)
+        throw new InvalidOperationException();
+    }
+
+    /// <summary>
+    ///     save img data to stream
+    /// </summary>
+    /// <param name="s"></param>
+    /// <returns></returns>
+    public Task SaveAsync(Stream s)
+    {
+        if (Img != null)
         {
-            if (Img == null)
-            {
-                throw new InvalidOperationException("This method can only be used when the cropper working in pure cs mode");
-            }
+            IImageEncoder encoder = GetImageEncoder(Format, Quality);
             return Img.SaveAsync(s, encoder);
         }
-#endif
 
-        public void Dispose()
-        {
-            Img?.Dispose();
-        }
+        if (_data != null) return s.WriteAsync(_data).AsTask();
+        if (_base64 == null) throw new InvalidOperationException();
+
+        _data = Convert.FromBase64String(_base64);
+        return s.WriteAsync(_data).AsTask();
     }
+
+    private IImageEncoder GetImageEncoder(IImageFormat format, int quality) //TODO this variables are never used
+    {
+        IImageEncoder encoder = Configuration.Default.ImageFormatsManager.FindEncoder(Format);
+        switch (encoder)
+        {
+            case JpegEncoder e:
+                e.Quality = Quality;
+                break;
+            case WebpEncoder e:
+                e.Quality = Quality;
+                break;
+        }
+
+        return encoder;
+    }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    ///     Save image to a stream with your own
+    ///     <see cref="IImageEncoder" />.
+    ///     This can be use to
+    ///     set some advanced options e.g. <see cref="PngCompressionLevel" /> for png.
+    ///     This method can only be used when the cropper working in pure cs mode
+    /// </summary>
+    /// <param name="s"></param>
+    /// <param name="encoder"></param>
+    /// <returns></returns>
+    public Task SaveAsync(Stream s, IImageEncoder encoder)
+    {
+        if (Img == null) throw new InvalidOperationException("This method can only be used when the cropper working in pure cs mode");
+        return Img.SaveAsync(s, encoder);
+    }
+#endif
 }

--- a/Blazor.Cropper/ImageCroppedResult.cs
+++ b/Blazor.Cropper/ImageCroppedResult.cs
@@ -55,7 +55,11 @@ public class ImageCroppedResult : IDisposable
     /// <exception cref="InvalidOperationException"></exception>
     public async Task<byte[]> GetDataAsync()
     {
-        if (_data != null) return _data;
+        if (_data != null)
+        {
+            return _data;
+        }
+
         if (_base64 != null)
         {
             _data = Convert.FromBase64String(_base64);
@@ -88,8 +92,15 @@ public class ImageCroppedResult : IDisposable
             return Img.SaveAsync(s, encoder);
         }
 
-        if (_data != null) return s.WriteAsync(_data).AsTask();
-        if (_base64 == null) throw new InvalidOperationException();
+        if (_data != null)
+        {
+            return s.WriteAsync(_data).AsTask();
+        }
+
+        if (_base64 == null)
+        {
+            throw new InvalidOperationException();
+        }
 
         _data = Convert.FromBase64String(_base64);
         return s.WriteAsync(_data).AsTask();
@@ -105,6 +116,8 @@ public class ImageCroppedResult : IDisposable
                 break;
             case WebpEncoder e:
                 e.Quality = Quality;
+                break;
+            default:
                 break;
         }
 

--- a/Blazor.Cropper/ImageCroppedResult.cs
+++ b/Blazor.Cropper/ImageCroppedResult.cs
@@ -7,7 +7,6 @@ using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.Formats.Webp;
 
-namespace Blazor.Cropper;
 
 public class ImageCroppedResult : IDisposable
 {

--- a/Blazor.Cropper/ImageData.cs
+++ b/Blazor.Cropper/ImageData.cs
@@ -1,5 +1,3 @@
-namespace Blazor.Cropper;
-
 internal class ImageData
 {
     public double Width { get; set; }

--- a/Blazor.Cropper/ImageData.cs
+++ b/Blazor.Cropper/ImageData.cs
@@ -1,3 +1,5 @@
+namespace Blazor.Cropper;
+
 internal class ImageData
 {
     public double Width { get; set; }

--- a/Blazor.Cropper/JSInterop.cs
+++ b/Blazor.Cropper/JSInterop.cs
@@ -1,8 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.JSInterop;
 
-namespace Blazor.Cropper;
-
 /// <summary>
 ///     js interop methods
 /// </summary>

--- a/Blazor.Cropper/JSInterop.cs
+++ b/Blazor.Cropper/JSInterop.cs
@@ -1,34 +1,25 @@
-﻿using Microsoft.JSInterop;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Microsoft.JSInterop;
 
-namespace Blazor.Cropper
+namespace Blazor.Cropper;
+
+/// <summary>
+///     js interop methods
+/// </summary>
+public static class JsInterop
 {
     /// <summary>
-    /// js interop methods
+    ///     set html img element to display the image
+    ///     this function is the preferred way to display the crop result in dotnet 6
     /// </summary>
-    public static class JSInterop
-    {
-        /// <summary>
-        /// set html img element to display the image
-        /// this function is the preferred way to display the crop result in dotnet 6
-        /// </summary>
-        /// <param name="js"></param>
-        /// <param name="bin">image bytes</param>
-        /// <param name="imgid">img element id</param>
-        /// <param name="format">like image/jpg</param>
-        /// <returns></returns>
-        public static ValueTask SetImageAsync(this IJSRuntime js,byte[] bin,string imgid, string format)
-        {
-            return js.InvokeVoidAsync("setSrc", bin, imgid,format);
-        }
+    /// <param name="js"></param>
+    /// <param name="bin">image bytes</param>
+    /// <param name="imgId">img element id</param>
+    /// <param name="format">like image/jpg</param>
+    /// <returns></returns>
+    public static ValueTask SetImageAsync(this IJSRuntime js, byte[] bin, string imgId, string format)
+        => js.InvokeVoidAsync("setSrc", bin, imgId, format);
 
-        public static ValueTask LogAsync(this IJSRuntime js,params object[] objs)
-        {
-            return js.InvokeVoidAsync("console.log", objs);
-        }
-    }
+    public static ValueTask LogAsync(this IJSRuntime js, params object[] objs)
+        => js.InvokeVoidAsync("console.log", objs);
 }

--- a/Blazor.Cropper/MoveDir.cs
+++ b/Blazor.Cropper/MoveDir.cs
@@ -1,4 +1,6 @@
-enum MoveDir
+namespace Blazor.Cropper;
+
+internal enum MoveDir
 {
     Up,
     Down,

--- a/Blazor.Cropper/MoveDir.cs
+++ b/Blazor.Cropper/MoveDir.cs
@@ -1,5 +1,3 @@
-namespace Blazor.Cropper;
-
 internal enum MoveDir
 {
     Up,

--- a/Blazor.Cropper/StreamFile.cs
+++ b/Blazor.Cropper/StreamFile.cs
@@ -3,8 +3,6 @@ using System.IO;
 using System.Threading;
 using Microsoft.AspNetCore.Components.Forms;
 
-namespace Blazor.Cropper;
-
 /// <summary>
 ///     mock a browserfile from a stream
 /// </summary>

--- a/Blazor.Cropper/StreamFile.cs
+++ b/Blazor.Cropper/StreamFile.cs
@@ -1,54 +1,56 @@
 ﻿using System;
 using System.IO;
-using Microsoft.AspNetCore.Components.Forms;
 using System.Threading;
+using Microsoft.AspNetCore.Components.Forms;
 
-namespace Blazor.Cropper
+namespace Blazor.Cropper;
+
+/// <summary>
+///     mock a browserfile from a stream
+/// </summary>
+public class StreamFile : IBrowserFile
 {
-    /// <summary>
-    /// mock a browserfile from a stream
-    /// </summary>
-    public class StreamFile : IBrowserFile
-    {
-        /// <summary>
-        /// Build a stream file
-        /// </summary>
-        /// <param name="stream"></param>
-        /// <param name="name"></param>
-        /// <param name="contentType"></param>
-        public StreamFile(Stream stream, string name = "1.jpg", string contentType= "image/jpg")
-        {
-            _stream = stream;
-            Name = name;
-            ContentType = contentType;
-        }
-        Stream _stream;
-        /// <summary>
-        /// name
-        /// </summary>
-        public string Name { get; set; }
-        /// <summary>
-        /// not impl
-        /// </summary>
-        public DateTimeOffset LastModified => throw new NotImplementedException();
-        /// <summary>
-        /// stream size
-        /// </summary>
-        public long Size => _stream.Length;
-        /// <summary>
-        /// content type, should in form of image/xxx
-        /// </summary>
-        public string ContentType { get; set; }
+    private readonly Stream _stream;
 
-        /// <summary>
-        /// open read stream
-        /// </summary>
-        /// <param name="maxAllowedSize"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = default)
-        {
-            return _stream;
-        }
+    /// <summary>
+    ///     Build a stream file
+    /// </summary>
+    /// <param name="stream"></param>
+    /// <param name="name"></param>
+    /// <param name="contentType"></param>
+    public StreamFile(Stream stream, string name = "1.jpg", string contentType = "image/jpg")
+    {
+        _stream = stream;
+        Name = name;
+        ContentType = contentType;
     }
+
+    /// <summary>
+    ///     name
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    ///     not impl
+    /// </summary>
+    public DateTimeOffset LastModified => throw new NotImplementedException();
+
+    /// <summary>
+    ///     stream size
+    /// </summary>
+    public long Size => _stream.Length;
+
+    /// <summary>
+    ///     content type, should in form of image/xxx
+    /// </summary>
+    public string ContentType { get; set; }
+
+    /// <summary>
+    ///     open read stream
+    /// </summary>
+    /// <param name="maxAllowedSize"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public Stream OpenReadStream(long maxAllowedSize = 512000, CancellationToken cancellationToken = default)
+        => _stream;
 }


### PR DESCRIPTION
For my database I need the images to always have the same size so I added 2 parameters (FinalCropHeight and FinalCropWidth) to the Cropper class and modified the GetCropedResult() method a little bit. Thats the only real change. I hope you dont mind but other than that, I just used ReSharper to do a basic cleanup/formatting of the code.  It should have no impact on the functionality.