### PR TITLE
fix: net7 blazor server stream read

### DIFF
--- a/Blazor.Cropper/Cropper.razor.cs
+++ b/Blazor.Cropper/Cropper.razor.cs
@@ -665,7 +665,7 @@ namespace Blazor.Cropper
             if (PureCSharpProcessing || string.IsNullOrEmpty(InputId) || (ext == "gif" && AnimeGifEnable))
             {
                 byte[] buffer = new byte[resizedImageFile.Size];
-                if (Environment.Version.Major == 6)
+                if (Environment.Version.Major >= 6)
                 {
                     var isClientSide = JSRuntime is IJSInProcessRuntime;
                     if (isClientSide)


### PR DESCRIPTION
The changes needed for the image stream reading to work with .net6 are still needed for .net7 (and possibly onwards for a while).